### PR TITLE
feat: dynamic branded OG images (nuxt-og-image)

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -14,6 +14,9 @@
 </template>
 
 <script setup lang="ts">
+// Site-wide default branded OG image. Pages override via defineOgImageComponent.
+defineOgImageComponent('Cambio')
+
 // Handle hydration and errors
 onErrorCaptured(error => {
   console.error('App error captured:', error)

--- a/app/components/OgImage/Cambio.vue
+++ b/app/components/OgImage/Cambio.vue
@@ -1,0 +1,208 @@
+<script setup lang="ts">
+import type { CSSProperties } from 'vue'
+
+// OG image template (1200x630) rendered server-side by nuxt-og-image via satori.
+// Satori supports a CSS subset: flexbox only, gradients, border, border-radius,
+// opacity, box-shadow. No grid, no backdrop-filter, no JS/motion.
+// Styles are defined as typed objects here (not inline) to keep the template
+// clean and avoid attribute-quoting issues with font names.
+const props = withDefaults(
+  defineProps<{
+    title?: string
+    subtitle?: string
+    tag?: string
+    rateBuy?: number | null
+    rateSell?: number | null
+  }>(),
+  {
+    title: 'Cotización del Dólar en Uruguay Hoy',
+    subtitle: 'Compará +40 casas de cambio en tiempo real',
+    tag: '',
+    rateBuy: null,
+    rateSell: null,
+  }
+)
+
+const fmt = (n: number): string =>
+  new Intl.NumberFormat('es-UY', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(n)
+
+const root: CSSProperties = {
+  width: '1200px',
+  height: '630px',
+  display: 'flex',
+  flexDirection: 'column',
+  position: 'relative',
+  padding: '64px 72px',
+  backgroundColor: '#0d0f14',
+  backgroundImage: 'linear-gradient(135deg, #0d0f14 0%, #15181f 55%, #0d0f14 100%)',
+  fontFamily: 'Open Sans',
+  overflow: 'hidden',
+}
+const glowGreen: CSSProperties = {
+  position: 'absolute',
+  top: '-220px',
+  left: '-160px',
+  width: '620px',
+  height: '620px',
+  borderRadius: '50%',
+  backgroundImage: 'radial-gradient(circle, rgba(22,199,132,0.30) 0%, rgba(22,199,132,0) 70%)',
+  display: 'flex',
+}
+const glowBlue: CSSProperties = {
+  position: 'absolute',
+  bottom: '-260px',
+  right: '-180px',
+  width: '640px',
+  height: '640px',
+  borderRadius: '50%',
+  backgroundImage: 'radial-gradient(circle, rgba(47,129,247,0.22) 0%, rgba(47,129,247,0) 70%)',
+  display: 'flex',
+}
+const accentBar: CSSProperties = {
+  position: 'absolute',
+  top: '0',
+  left: '0',
+  width: '1200px',
+  height: '8px',
+  backgroundImage: 'linear-gradient(90deg, #16c784 0%, #2f81f7 100%)',
+  display: 'flex',
+}
+const header: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+}
+const brand: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  marginRight: 'auto',
+  fontSize: '34px',
+  fontWeight: 800,
+  letterSpacing: '2px',
+  color: '#ffffff',
+}
+const dollarMark: CSSProperties = { color: '#16c784', margin: '0 14px', fontSize: '40px' }
+const tagChip: CSSProperties = {
+  display: 'flex',
+  padding: '10px 22px',
+  borderRadius: '999px',
+  border: '1px solid rgba(22,199,132,0.5)',
+  backgroundColor: 'rgba(22,199,132,0.12)',
+  color: '#16c784',
+  fontSize: '22px',
+  fontWeight: 700,
+  letterSpacing: '2px',
+}
+const main: CSSProperties = {
+  display: 'flex',
+  flex: '1',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  marginTop: '24px',
+}
+const titleStyle: CSSProperties = {
+  display: 'flex',
+  fontFamily: 'Sora',
+  fontWeight: 800,
+  fontSize: '56px',
+  lineHeight: 1.08,
+  color: '#ffffff',
+}
+const subtitleStyle: CSSProperties = {
+  display: 'flex',
+  marginTop: '22px',
+  fontSize: '30px',
+  color: '#9aa4b2',
+}
+const rateCard: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '300px',
+  padding: '26px 22px',
+  marginLeft: '40px',
+  borderRadius: '24px',
+  border: '1px solid rgba(22,199,132,0.45)',
+  backgroundColor: 'rgba(255,255,255,0.04)',
+  boxShadow: '0 20px 60px rgba(0,0,0,0.45)',
+}
+const rateLabel: CSSProperties = {
+  display: 'flex',
+  fontSize: '26px',
+  color: '#9aa4b2',
+  fontWeight: 700,
+  letterSpacing: '3px',
+}
+const rateValue: CSSProperties = {
+  display: 'flex',
+  fontFamily: 'Sora',
+  fontWeight: 800,
+  fontSize: '74px',
+  color: '#16c784',
+  lineHeight: 1.1,
+}
+const rateBuyStyle: CSSProperties = { display: 'flex', fontSize: '24px', color: '#cdd5df' }
+const bigDollar: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  fontFamily: 'Sora',
+  fontWeight: 800,
+  fontSize: '300px',
+  color: 'rgba(22,199,132,0.14)',
+  marginLeft: '20px',
+}
+const footer: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  fontSize: '24px',
+  color: '#7b8694',
+}
+const footerBrand: CSSProperties = { color: '#ffffff', fontWeight: 700 }
+const dot: CSSProperties = { margin: '0 16px' }
+const titleCol = (hasRate: boolean): CSSProperties => ({
+  display: 'flex',
+  flexDirection: 'column',
+  maxWidth: hasRate ? '640px' : '900px',
+})
+</script>
+
+<template>
+  <div :style="root">
+    <div :style="glowGreen" />
+    <div :style="glowBlue" />
+    <div :style="accentBar" />
+
+    <div :style="header">
+      <div :style="brand">
+        <span>CAMBIO</span>
+        <span :style="dollarMark">$</span>
+        <span>URUGUAY</span>
+      </div>
+      <div v-if="tag" :style="tagChip">{{ tag }}</div>
+    </div>
+
+    <div :style="main">
+      <div :style="titleCol(!!props.rateSell)">
+        <div :style="titleStyle">{{ title }}</div>
+        <div :style="subtitleStyle">{{ subtitle }}</div>
+      </div>
+
+      <div v-if="props.rateSell" :style="rateCard">
+        <div :style="rateLabel">DÓLAR USD</div>
+        <div :style="rateValue">${{ fmt(props.rateSell) }}</div>
+        <div v-if="props.rateBuy" :style="rateBuyStyle">compra ${{ fmt(props.rateBuy) }}</div>
+      </div>
+      <div v-else :style="bigDollar">$</div>
+    </div>
+
+    <div :style="footer">
+      <span :style="footerBrand">cambio-uruguay.com</span>
+      <span :style="dot">•</span>
+      <span>+40 casas de cambio</span>
+      <span :style="dot">•</span>
+      <span>actualizado cada 10 min</span>
+    </div>
+  </div>
+</template>

--- a/app/nuxt.config.ts
+++ b/app/nuxt.config.ts
@@ -53,33 +53,17 @@ export default defineNuxtConfig({
         { name: 'bingbot', content: 'index, follow' },
         { name: 'referrer', content: 'no-referrer' },
 
-        // Open Graph / Facebook - Only truly global properties
+        // Open Graph / Facebook. og:image and twitter:image are generated PER PAGE
+        // by nuxt-og-image (see `ogImage` config + defineOgImageComponent), so they
+        // are intentionally NOT hardcoded here — avoids duplicate/competing tags.
         { property: 'og:type', content: 'website' },
-        {
-          property: 'og:image',
-          content: 'https://cambio-uruguay.com/img/og.png',
-        },
-        { property: 'og:image:width', content: '1200' },
-        { property: 'og:image:height', content: '630' },
-        {
-          property: 'og:image:alt',
-          content: 'Cambio Uruguay - Cotización del dólar en Uruguay hoy',
-        },
         { property: 'og:site_name', content: 'Cambio Uruguay' },
         { property: 'og:locale', content: 'es_ES' },
         { property: 'og:locale:alternate', content: 'en_US' },
         { property: 'og:locale:alternate', content: 'pt_BR' },
 
-        // Twitter Card - Only truly global properties
+        // Twitter Card
         { name: 'twitter:card', content: 'summary_large_image' },
-        {
-          name: 'twitter:image',
-          content: 'https://cambio-uruguay.com/img/banner.png',
-        },
-        {
-          name: 'twitter:image:alt',
-          content: 'Cambio Uruguay - Cotización del dólar en Uruguay hoy',
-        },
         { name: 'twitter:site', content: '@cambio_uruguay' },
         { name: 'twitter:creator', content: '@cambio_uruguay' },
 
@@ -425,6 +409,16 @@ export default defineNuxtConfig({
   // Sitemap Configuration
   sitemap: {
     sources: ['/api/__sitemap__/urls'],
+  },
+
+  // OG image generation (nuxt-og-image, bundled with @nuxtjs/seo).
+  // Branded per-page social previews via the OgImage/Cambio component.
+  ogImage: {
+    fonts: ['Open Sans:400', 'Open Sans:600', 'Open Sans:800', 'Sora:700', 'Sora:800'],
+    defaults: {
+      width: 1200,
+      height: 630,
+    },
   },
 
   // i18n Configuration

--- a/app/pages/comparar.vue
+++ b/app/pages/comparar.vue
@@ -403,6 +403,13 @@ const formatOriginName = (origin: string): string => {
   return origin.replace(/[-_]/g, ' ').replace(/\b\w/g, l => l.toUpperCase())
 }
 
+// Branded OG image for the comparison page
+defineOgImageComponent('Cambio', {
+  title: 'Comparar Casas de Cambio',
+  subtitle: 'Superponé la evolución de varias casas en el tiempo',
+  tag: 'COMPARADOR',
+})
+
 // SEO
 useSeoMeta({
   title: () => t('seo.compareTitle'),

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -823,6 +823,18 @@ const apiService = useApiService()
 const route = useRoute()
 const router = useRouter()
 
+// Branded OG image with the live USD rate (og-rate route is cached 10 min).
+const { data: ogRate } = await useFetch<{ buy: number | null; sell: number | null }>(
+  '/api/og-rate',
+  { default: () => ({ buy: null, sell: null }) }
+)
+defineOgImageComponent('Cambio', {
+  title: 'Cotización del Dólar en Uruguay',
+  subtitle: 'Compará +40 casas de cambio en tiempo real',
+  rateBuy: ogRate.value?.buy ?? null,
+  rateSell: ogRate.value?.sell ?? null,
+})
+
 // localStorage key for form persistence
 const STORAGE_KEY = 'cambio-uruguay-home-form'
 

--- a/app/pages/noticias.vue
+++ b/app/pages/noticias.vue
@@ -156,6 +156,13 @@ const relativeDate = (dateStr: string) => {
   return rtf.format(Math.round(diffMin / 1440), 'day')
 }
 
+// Branded OG image for the news page
+defineOgImageComponent('Cambio', {
+  title: 'Noticias del Dólar en Uruguay',
+  subtitle: 'Resumen con IA + titulares de los principales medios',
+  tag: 'NOTICIAS',
+})
+
 // SEO
 useSeoMeta({
   title: () => t('noticias.metaTitle'),

--- a/app/server/api/og-rate.get.ts
+++ b/app/server/api/og-rate.get.ts
@@ -1,0 +1,23 @@
+// Current best USD market rate for the OG image (cached 10 min so it never
+// adds real cost to page SSR). Returns the best market sell (cheapest to buy)
+// and best buy (pays most for your USD), plain/cash quotes only.
+import type { ExchangeRate } from '../../types/api'
+
+export default defineCachedEventHandler(
+  async (): Promise<{ buy: number | null; sell: number | null }> => {
+    const apiBase = useRuntimeConfig().public.apiBase as string
+    const rates = await $fetch<ExchangeRate[]>('/', { baseURL: apiBase }).catch(
+      () => [] as ExchangeRate[]
+    )
+    const usd = rates.filter(
+      r => r.code === 'USD' && (!r.type || r.type === '') && r.origin !== 'bcu'
+    )
+    const sells = usd.map(r => r.sell ?? 0).filter(v => v > 0)
+    const buys = usd.map(r => r.buy ?? 0).filter(v => v > 0)
+    return {
+      sell: sells.length ? Math.min(...sells) : null,
+      buy: buys.length ? Math.max(...buys) : null,
+    }
+  },
+  { maxAge: 60 * 10, staleMaxAge: 60 * 60, name: 'og-rate', getKey: () => 'usd' }
+)


### PR DESCRIPTION
Per-page branded social previews (1200x630) so embeds look nice: dark gradient + green accent, Sora/Open Sans, brand mark. Home shows the live USD rate (cached /api/og-rate, 10 min); /noticias and /comparar get tailored variants; other pages use the branded default. Removed the hardcoded static og:image. Verified rendered output (satori) for home + noticias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)