### PR TITLE
feat: embeddable /widget + hreflang alternates

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -2,7 +2,10 @@
   <div>
     <!-- Main App -->
     <NuxtLoadingIndicator />
-    <NuxtLayout name="default">
+    <!-- No explicit name: NuxtLayout reads the layout from route meta, so each
+         page's definePageMeta({ layout }) is honored (defaulting to 'default').
+         Lets bare pages like /widget opt out of the default app shell. -->
+    <NuxtLayout>
       <NuxtPage />
     </NuxtLayout>
 

--- a/app/i18n/locales/json/en.json
+++ b/app/i18n/locales/json/en.json
@@ -541,6 +541,18 @@
     "disclaimerText": "The information on Cambio Uruguay is informational and educational. It does not constitute financial, tax or investment advice, nor a recommendation to buy or sell currency. Always verify the rate and conditions directly with the exchange house before operating.",
     "ctaTitle": "Compare and decide with data",
     "ctaText": "Check the dollar rate across more than 40 exchange houses, or dig deeper with our guides.",
-    "ctaButton": "View rates"
+    "ctaButton": "View rates",
+    "embedTitle": "Embed the widget",
+    "embedText": "Have a website or blog? Add the live dollar rate with our widget. Copy this code and paste it into your page:",
+    "embedCopy": "Copy code",
+    "embedCopied": "Copied!"
+  },
+  "widget": {
+    "live": "Live",
+    "buy": "Buy",
+    "sell": "Sell",
+    "backlink": "Live rate · cambio-uruguay.com",
+    "metaTitle": "Uruguay dollar rate widget",
+    "metaDescription": "Embeddable widget with the best dollar rate (buy and sell) in Uruguay, updated live."
   }
 }

--- a/app/i18n/locales/json/es.json
+++ b/app/i18n/locales/json/es.json
@@ -551,7 +551,19 @@
     "disclaimerText": "La información de Cambio Uruguay es de carácter informativo y educativo. No constituye asesoramiento financiero, fiscal ni de inversión, ni una recomendación de compra o venta de divisas. Verificá siempre la cotización y las condiciones directamente con la casa de cambio antes de operar.",
     "ctaTitle": "Compará y decidí con datos",
     "ctaText": "Mirá la cotización del dólar en más de 40 casas de cambio o profundizá con nuestras guías.",
-    "ctaButton": "Ver cotizaciones"
+    "ctaButton": "Ver cotizaciones",
+    "embedTitle": "Insertá el widget",
+    "embedText": "¿Tenés un sitio web o blog? Sumá la cotización del dólar en vivo con nuestro widget. Copiá este código y pegalo en tu página:",
+    "embedCopy": "Copiar código",
+    "embedCopied": "¡Copiado!"
+  },
+  "widget": {
+    "live": "En vivo",
+    "buy": "Compra",
+    "sell": "Venta",
+    "backlink": "Cotización en vivo · cambio-uruguay.com",
+    "metaTitle": "Widget de cotización del dólar en Uruguay",
+    "metaDescription": "Widget embebible con la mejor cotización del dólar (compra y venta) en Uruguay, actualizada en vivo."
   },
   "loading": "Cargando"
 }

--- a/app/i18n/locales/json/pt.json
+++ b/app/i18n/locales/json/pt.json
@@ -534,6 +534,18 @@
     "disclaimerText": "As informações do Cambio Uruguay têm caráter informativo e educativo. Não constituem aconselhamento financeiro, fiscal ou de investimento, nem recomendação de compra ou venda de divisas. Verifique sempre a cotação e as condições diretamente com a casa de câmbio antes de operar.",
     "ctaTitle": "Compare e decida com dados",
     "ctaText": "Veja a cotação do dólar em mais de 40 casas de câmbio ou aprofunde-se com nossos guias.",
-    "ctaButton": "Ver cotações"
+    "ctaButton": "Ver cotações",
+    "embedTitle": "Insira o widget",
+    "embedText": "Tem um site ou blog? Adicione a cotação do dólar ao vivo com o nosso widget. Copie este código e cole na sua página:",
+    "embedCopy": "Copiar código",
+    "embedCopied": "Copiado!"
+  },
+  "widget": {
+    "live": "Ao vivo",
+    "buy": "Compra",
+    "sell": "Venda",
+    "backlink": "Cotação ao vivo · cambio-uruguay.com",
+    "metaTitle": "Widget de cotação do dólar no Uruguai",
+    "metaDescription": "Widget incorporável com a melhor cotação do dólar (compra e venda) no Uruguai, atualizada ao vivo."
   }
 }

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -346,6 +346,17 @@ const isActiveRoute = (path: string) => {
   return route.path.startsWith(path)
 }
 
+// hreflang alternates: feed @nuxtjs/i18n's localized head (rel=alternate
+// hreflang links for es/en/pt + x-default, plus htmlAttrs lang/dir) into useHead
+// at the layout level so every page emits them. Kept separate from the static
+// useHead below to avoid clobbering the existing canonical/meta/JSON-LD.
+const i18nHead = useLocaleHead()
+useHead(() => ({
+  htmlAttrs: i18nHead.value.htmlAttrs ?? {},
+  link: i18nHead.value.link ?? [],
+  meta: i18nHead.value.meta ?? [],
+}))
+
 // Head configuration
 useHead({
   link: [

--- a/app/layouts/widget.vue
+++ b/app/layouts/widget.vue
@@ -1,0 +1,30 @@
+<template>
+  <!-- Bare, full-bleed layout for the embeddable /widget iframe. No VAppBar,
+       drawer or Footer so it renders chrome-free inside third-party pages. -->
+  <VApp class="widget-layout">
+    <VMain>
+      <slot />
+    </VMain>
+  </VApp>
+</template>
+
+<script setup lang="ts">
+// hreflang alternates are still useful here so the embeddable page advertises
+// its localized variants; reuse the same i18n head wiring as the default layout.
+const i18nHead = useLocaleHead()
+useHead(() => ({
+  htmlAttrs: i18nHead.value.htmlAttrs ?? {},
+  link: i18nHead.value.link ?? [],
+  meta: i18nHead.value.meta ?? [],
+}))
+</script>
+
+<style scoped>
+.widget-layout {
+  background: transparent;
+}
+
+.widget-layout :deep(.v-main) {
+  padding: 0 !important;
+}
+</style>

--- a/app/nuxt.config.ts
+++ b/app/nuxt.config.ts
@@ -187,6 +187,16 @@ export default defineNuxtConfig({
         'Referrer-Policy': 'strict-origin-when-cross-origin',
       },
     },
+    // Embeddable widget: must be framable from any third-party domain. Clear any
+    // X-Frame-Options and allow all frame-ancestors so the iframe snippet works.
+    '/widget': {
+      ssr: true,
+      headers: {
+        'cache-control': 's-maxage=300',
+        'X-Frame-Options': '',
+        'Content-Security-Policy': 'frame-ancestors *',
+      },
+    },
     '/_nuxt/**': {
       headers: { 'cache-control': 'max-age=31536000, immutable' },
     },

--- a/app/pages/acerca.vue
+++ b/app/pages/acerca.vue
@@ -138,6 +138,35 @@
             </p>
           </section>
 
+          <!-- Insertá el widget (embeddable iframe -> backlinks) -->
+          <section class="mb-8">
+            <h2 class="text-h5 font-weight-bold mb-3">{{ t('acerca.embedTitle') }}</h2>
+            <p class="text-body-1 text-grey-lighten-1 about-prose mb-4">
+              {{ t('acerca.embedText') }}
+            </p>
+            <div class="embed-snippet">
+              <VTextarea
+                :model-value="embedSnippet"
+                readonly
+                variant="solo-filled"
+                rows="3"
+                auto-grow
+                hide-details
+                class="embed-code"
+                :aria-label="t('acerca.embedTitle')"
+              />
+              <VBtn
+                color="primary"
+                variant="tonal"
+                class="mt-2"
+                :prepend-icon="copied ? 'mdi-check' : 'mdi-content-copy'"
+                @click="copyEmbed"
+              >
+                {{ copied ? t('acerca.embedCopied') : t('acerca.embedCopy') }}
+              </VBtn>
+            </div>
+          </section>
+
           <!-- Disclaimer -->
           <VAlert type="warning" variant="tonal" class="mb-8" :title="t('acerca.disclaimerTitle')">
             {{ t('acerca.disclaimerText') }}
@@ -190,6 +219,30 @@ const rateTypes = computed<RateTypeRow[]>(() => [
   { code: 'TRANSFERENCIA', desc: t('acerca.typeTransferencia') },
   { code: 'INTERBANCARIO', desc: t('acerca.typeInterbancario') },
 ])
+
+// Copy-paste iframe snippet for the embeddable live-rate widget. Sites that
+// embed it link back to cambio-uruguay.com (the backlink lives inside /widget).
+const embedSnippet =
+  '<iframe src="https://cambio-uruguay.com/widget" width="320" height="180" frameborder="0" title="Cotización del dólar en Uruguay"></iframe>'
+
+const copied = ref(false)
+let copiedTimer: ReturnType<typeof setTimeout> | null = null
+const copyEmbed = async () => {
+  try {
+    await navigator.clipboard.writeText(embedSnippet)
+    copied.value = true
+    if (copiedTimer) clearTimeout(copiedTimer)
+    copiedTimer = setTimeout(() => {
+      copied.value = false
+    }, 2000)
+  } catch {
+    // Clipboard API unavailable (insecure context / denied): the textarea is
+    // selectable so the user can still copy manually.
+  }
+}
+onBeforeUnmount(() => {
+  if (copiedTimer) clearTimeout(copiedTimer)
+})
 
 const canonicalUrl = 'https://cambio-uruguay.com/acerca'
 
@@ -304,6 +357,12 @@ useHead({
 
 .about-link:hover {
   text-decoration: underline;
+}
+
+.embed-code :deep(textarea) {
+  font-family: 'Courier New', ui-monospace, monospace;
+  font-size: 0.8rem;
+  line-height: 1.5;
 }
 
 /* Readable CTA on dark theme (avoid Vuetify outlined color tinting the text) */

--- a/app/pages/widget.vue
+++ b/app/pages/widget.vue
@@ -1,0 +1,228 @@
+<template>
+  <div class="widget" data-testid="widget">
+    <div class="widget-inner">
+      <header class="widget-head">
+        <span class="widget-brand">cambio-uruguay.com</span>
+        <span class="widget-badge">
+          <span class="widget-dot" :class="{ 'widget-dot--live': hasRate }" />
+          {{ t('widget.live') }}
+        </span>
+      </header>
+
+      <div class="widget-body">
+        <div class="widget-cell">
+          <span class="widget-label">{{ t('widget.buy') }}</span>
+          <span class="widget-value" data-testid="widget-buy">{{ buyDisplay }}</span>
+        </div>
+        <div class="widget-sep" />
+        <div class="widget-cell">
+          <span class="widget-label">{{ t('widget.sell') }}</span>
+          <span class="widget-value" data-testid="widget-sell">{{ sellDisplay }}</span>
+        </div>
+      </div>
+
+      <footer class="widget-foot">
+        <a
+          class="widget-link"
+          href="https://cambio-uruguay.com"
+          target="_blank"
+          rel="noopener"
+          data-testid="widget-backlink"
+        >
+          {{ t('widget.backlink') }}
+        </a>
+      </footer>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// Embeddable, iframe-friendly widget that shows the live best USD compra/venta.
+// Uses the bare `widget` layout (no site nav/footer) and the same cached
+// `/api/og-rate` endpoint as the OG image. The backlink to cambio-uruguay.com
+// is the whole point of the widget (drives referral traffic + backlinks).
+definePageMeta({ layout: 'widget' })
+
+interface OgRate {
+  buy: number | null
+  sell: number | null
+}
+
+const { t } = useI18n()
+
+const { data: rate, refresh } = await useFetch<OgRate>('/api/og-rate', {
+  key: 'widget-og-rate',
+  default: (): OgRate => ({ buy: null, sell: null }),
+})
+
+const hasRate = computed(() => rate.value.buy !== null || rate.value.sell !== null)
+
+const formatRate = (value: number | null): string => {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '—'
+  return value.toLocaleString('es-UY', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+}
+
+const buyDisplay = computed(() => formatRate(rate.value.buy))
+const sellDisplay = computed(() => formatRate(rate.value.sell))
+
+// Auto-refresh the live rate ~every 60s while the iframe is mounted (client only).
+const REFRESH_MS = 60_000
+let timer: ReturnType<typeof setInterval> | null = null
+onMounted(() => {
+  timer = setInterval(() => {
+    void refresh()
+  }, REFRESH_MS)
+})
+onBeforeUnmount(() => {
+  if (timer) clearInterval(timer)
+})
+
+useSeoMeta({
+  title: () => t('widget.metaTitle'),
+  description: () => t('widget.metaDescription'),
+  ogTitle: () => t('widget.metaTitle'),
+  ogDescription: () => t('widget.metaDescription'),
+  ogType: 'website',
+})
+</script>
+
+<style scoped>
+.widget {
+  width: 100%;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #1a1d24;
+  font-family:
+    'Open Sans',
+    system-ui,
+    -apple-system,
+    sans-serif;
+  color: #fff;
+}
+
+.widget-inner {
+  width: 100%;
+  max-width: 320px;
+  padding: 14px 16px;
+  box-sizing: border-box;
+  background: linear-gradient(135deg, #1f2530 0%, #161a21 100%);
+  border: 1px solid rgba(33, 150, 243, 0.28);
+  border-radius: 12px;
+}
+
+.widget-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.widget-brand {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: #64b5f6;
+  letter-spacing: 0.2px;
+}
+
+.widget-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.62rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.widget-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.widget-dot--live {
+  background: #4caf50;
+  box-shadow: 0 0 0 0 rgba(76, 175, 80, 0.6);
+  animation: widget-pulse 2s infinite;
+}
+
+@keyframes widget-pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(76, 175, 80, 0.5);
+  }
+  70% {
+    box-shadow: 0 0 0 6px rgba(76, 175, 80, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(76, 175, 80, 0);
+  }
+}
+
+.widget-body {
+  display: flex;
+  align-items: stretch;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 10px;
+  padding: 10px 4px;
+}
+
+.widget-cell {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.widget-sep {
+  width: 1px;
+  background: rgba(255, 255, 255, 0.1);
+  margin: 2px 0;
+}
+
+.widget-label {
+  font-size: 0.66rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.widget-value {
+  font-size: 1.5rem;
+  font-weight: 800;
+  line-height: 1.1;
+  color: #fff;
+}
+
+.widget-value::before {
+  content: '$ ';
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.widget-foot {
+  margin-top: 10px;
+  text-align: center;
+}
+
+.widget-link {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.7);
+  text-decoration: none;
+}
+
+.widget-link:hover {
+  color: #64b5f6;
+  text-decoration: underline;
+}
+</style>

--- a/app/tests/e2e/widget.spec.ts
+++ b/app/tests/e2e/widget.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from '@playwright/test'
+
+// e2e for the embeddable /widget page (bare layout, no site chrome) and a
+// regression check that the SSR home page now emits hreflang alternate links.
+// Cold Nuxt dev start compiles each route on first hit, so allow generous time.
+test.describe('widget embebible', () => {
+  test.setTimeout(120_000)
+
+  test('/widget shows a USD value and the cambio-uruguay.com backlink', async ({ page }) => {
+    await page.goto('/widget')
+
+    const widget = page.getByTestId('widget')
+    await expect(widget).toBeVisible({ timeout: 90_000 })
+
+    // At least one of buy/sell renders a numeric value (live cached rate).
+    const buy = page.getByTestId('widget-buy')
+    const sell = page.getByTestId('widget-sell')
+    await expect(buy).toBeVisible({ timeout: 90_000 })
+    await expect
+      .poll(
+        async () => {
+          const b = (await buy.textContent()) ?? ''
+          const s = (await sell.textContent()) ?? ''
+          return /\d/.test(b) || /\d/.test(s)
+        },
+        { timeout: 90_000 }
+      )
+      .toBe(true)
+
+    // The backlink to the main site (the whole point of the widget).
+    const backlink = page.getByTestId('widget-backlink')
+    await expect(backlink).toHaveAttribute('href', 'https://cambio-uruguay.com')
+    await expect(backlink).toHaveAttribute('target', '_blank')
+    await expect(backlink).toContainText(/cambio-uruguay\.com/i)
+  })
+
+  test('/widget uses the bare layout (no site nav / app bar)', async ({ page }) => {
+    await page.goto('/widget')
+    await expect(page.getByTestId('widget')).toBeVisible({ timeout: 90_000 })
+
+    // The default layout's VAppBar and desktop nav buttons must be absent.
+    await expect(page.locator('.v-app-bar')).toHaveCount(0)
+    await expect(page.locator('header.v-toolbar')).toHaveCount(0)
+    await expect(page.locator('img.logo_image')).toHaveCount(0)
+  })
+})
+
+test.describe('hreflang alternates', () => {
+  test.setTimeout(120_000)
+
+  test('/ SSR response includes hreflang alternate links (es/en/pt/x-default)', async ({
+    page,
+  }) => {
+    await page.goto('/')
+    await expect(page.locator('h1').first()).toBeVisible({ timeout: 90_000 })
+
+    const alternates = page.locator('link[rel="alternate"][hreflang]')
+    await expect.poll(async () => alternates.count(), { timeout: 90_000 }).toBeGreaterThanOrEqual(4)
+
+    // es/en/pt + x-default must all be present (>=1 each; the i18n module also
+    // emits the iso variants es-ES/en-US/pt-PT alongside the bare codes).
+    await expect
+      .poll(async () => page.locator('link[rel="alternate"][hreflang="es"]').count())
+      .toBeGreaterThanOrEqual(1)
+    await expect
+      .poll(async () => page.locator('link[rel="alternate"][hreflang="en"]').count())
+      .toBeGreaterThanOrEqual(1)
+    await expect
+      .poll(async () => page.locator('link[rel="alternate"][hreflang="pt"]').count())
+      .toBeGreaterThanOrEqual(1)
+    await expect
+      .poll(async () => page.locator('link[rel="alternate"][hreflang="x-default"]').count())
+      .toBeGreaterThanOrEqual(1)
+  })
+})


### PR DESCRIPTION
Framable live-rate widget (backlink driver) + iframe snippet on /acerca; hreflang es/en/pt/x-default via useLocaleHead. Full suite green (19 e2e, 102 unit), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)