### PR TITLE
fix(newsletter): escape @ in i18n placeholder (SSR 500)

### DIFF
--- a/app/i18n/locales/json/en.json
+++ b/app/i18n/locales/json/en.json
@@ -4,7 +4,7 @@
     "title": "Dollar newsletter",
     "subtitle": "Get the daily Uruguay dollar summary in your inbox.",
     "emailLabel": "Your email",
-    "emailPlaceholder": "you@example.com",
+    "emailPlaceholder": "you{'@'}example.com",
     "subscribe": "Subscribe",
     "consent": "We'll send a confirmation email. You can unsubscribe anytime.",
     "sent": "Check your inbox! We sent you a link to confirm your subscription.",

--- a/app/i18n/locales/json/es.json
+++ b/app/i18n/locales/json/es.json
@@ -4,7 +4,7 @@
     "title": "Newsletter del dólar",
     "subtitle": "Recibí cada día el resumen del dólar en Uruguay en tu correo.",
     "emailLabel": "Tu correo electrónico",
-    "emailPlaceholder": "tucorreo@ejemplo.com",
+    "emailPlaceholder": "tucorreo{'@'}ejemplo.com",
     "subscribe": "Suscribirme",
     "consent": "Te enviaremos un correo para confirmar. Podés cancelar cuando quieras.",
     "sent": "¡Revisá tu correo! Te enviamos un enlace para confirmar la suscripción.",

--- a/app/i18n/locales/json/pt.json
+++ b/app/i18n/locales/json/pt.json
@@ -4,7 +4,7 @@
     "title": "Newsletter do dólar",
     "subtitle": "Receba todos os dias o resumo do dólar no Uruguai no seu e-mail.",
     "emailLabel": "Seu e-mail",
-    "emailPlaceholder": "voce@exemplo.com",
+    "emailPlaceholder": "voce{'@'}exemplo.com",
     "subscribe": "Inscrever-me",
     "consent": "Enviaremos um e-mail de confirmação. Você pode cancelar quando quiser.",
     "sent": "Confira seu e-mail! Enviamos um link para confirmar a inscrição.",

--- a/app/tests/unit/newsletter-i18n.test.ts
+++ b/app/tests/unit/newsletter-i18n.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import es from '../../i18n/locales/json/es.json'
+import en from '../../i18n/locales/json/en.json'
+import pt from '../../i18n/locales/json/pt.json'
+
+describe('newsletter i18n compiles (no vue-i18n syntax errors)', () => {
+  for (const [loc, msg] of [['es', es], ['en', en], ['pt', pt]] as const) {
+    it(`${loc} newsletter keys render`, () => {
+      const i18n = createI18n({ legacy: false, locale: loc, messages: { [loc]: msg } })
+      const t = i18n.global.t as (k: string) => string
+      // Touch every newsletter key — a bad @/{} would throw at compile time.
+      for (const k of Object.keys((msg as Record<string, Record<string, string>>).newsletter)) {
+        expect(typeof t(`newsletter.${k}`)).toBe('string')
+      }
+      expect(t('newsletter.emailPlaceholder')).toContain('@')
+    })
+  }
+})


### PR DESCRIPTION
vue-i18n treats @ as linked-message syntax → SSR SyntaxError → /newsletter 500. Escape as {'@'} + regression test.