### PR TITLE
feat(import-tool): product-type selector (IVA, trámites, prohibidos)

### DIFF
--- a/app/pages/herramientas/calculadora-impuestos-importacion.vue
+++ b/app/pages/herramientas/calculadora-impuestos-importacion.vue
@@ -43,6 +43,91 @@
         </VBtnToggle>
       </template>
 
+      <!-- Product type: drives IVA, IMESI and required procedures -->
+      <div class="text-overline text-grey mb-2">Tipo de producto</div>
+      <VSelect
+        v-model="productTypeId"
+        :items="IMPORT_PRODUCT_TYPES"
+        item-title="label"
+        item-value="id"
+        variant="outlined"
+        density="comfortable"
+        prepend-inner-icon="mdi-shape-outline"
+        hide-details
+        class="mb-3"
+      >
+        <template #item="{ props: itemProps, item }">
+          <VListItem v-bind="itemProps" :prepend-icon="item.raw.icon" />
+        </template>
+      </VSelect>
+
+      <!-- Status: IVA treatment, required procedures, prohibitions -->
+      <div class="d-flex flex-wrap align-center ga-2 mb-2">
+        <VChip
+          size="small"
+          variant="tonal"
+          :color="productType.iva === 'exento' ? 'success' : 'primary'"
+          prepend-icon="mdi-cash"
+        >
+          {{
+            productType.iva === 'exento'
+              ? 'No paga IVA (exento)'
+              : `IVA ${productTax.ivaPct}%`
+          }}
+        </VChip>
+        <VChip
+          v-if="productType.imesi"
+          size="small"
+          variant="tonal"
+          color="warning"
+          prepend-icon="mdi-fuel"
+        >
+          Paga IMESI
+        </VChip>
+        <VChip
+          v-for="proc in productType.procedures"
+          :key="proc.organism"
+          size="small"
+          variant="tonal"
+          color="info"
+          prepend-icon="mdi-file-document-check-outline"
+          :href="proc.url"
+          target="_blank"
+          rel="noopener"
+        >
+          Trámite: {{ ORGANISM_LABEL[proc.organism] }}
+        </VChip>
+      </div>
+
+      <VAlert
+        v-if="regimeStatus.blocked"
+        type="error"
+        variant="tonal"
+        density="comfortable"
+        class="mb-3"
+        icon="mdi-cancel"
+      >
+        {{ regimeStatus.reason }}
+      </VAlert>
+      <VAlert
+        v-else-if="productType.procedures?.length"
+        type="info"
+        variant="tonal"
+        density="comfortable"
+        class="mb-3"
+        icon="mdi-information-outline"
+      >
+        Antes de despachar necesitás un trámite ante
+        {{ productType.procedures.map(p => ORGANISM_LABEL[p.organism]).join(' y ') }}.
+        <span v-if="productType.note">{{ productType.note }}</span>
+      </VAlert>
+      <p
+        v-else-if="productType.note"
+        class="text-caption text-grey-lighten-1 mb-3"
+      >
+        {{ productType.note }}
+      </p>
+
       <!-- Core inputs -->
       <VRow class="g-input">
         <VCol cols="12" sm="6">
@@ -149,6 +234,20 @@
               hide-details
             />
           </VCol>
+          <VCol v-if="showImesiField" cols="12" sm="3">
+            <VTextField
+              v-model.number="imesiPct"
+              type="number"
+              min="0"
+              label="IMESI"
+              suffix="%"
+              placeholder="ej. 20"
+              variant="outlined"
+              density="comfortable"
+              hint="Varía mucho según el producto: ingresá la tasa de tu caso."
+              persistent-hint
+            />
+          </VCol>
         </template>
       </VRow>
 
@@ -226,8 +325,16 @@
 
       <VDivider class="my-6" />
 
+      <!-- When the product can't enter under this regime, the estimate is shown
+           dimmed under a warning: the math still illustrates the cost, but it is
+           not actionable. -->
+      <p v-if="regimeStatus.blocked" class="text-caption text-error mb-3">
+        <VIcon size="small" start>mdi-alert</VIcon>
+        Estimación a título informativo: este producto no puede importarse por este régimen.
+      </p>
+
       <!-- Result -->
-      <div class="result-grid">
+      <div class="result-grid" :class="{ 'result-blocked': regimeStatus.blocked }">
         <div class="result-box">
           <div class="text-overline text-grey">Impuestos estimados</div>
           <div class="text-h5 font-weight-bold text-primary">{{ formatUSD(result.totalTax) }}</div>
@@ -248,7 +355,11 @@
       </div>
 
       <!-- Breakdown -->
-      <VTable density="comfortable" class="mt-5 breakdown-table">
+      <VTable
+        density="comfortable"
+        class="mt-5 breakdown-table"
+        :class="{ 'result-blocked': regimeStatus.blocked }"
+      >
         <tbody>
           <tr v-for="(line, i) in result.breakdown" :key="i">
             <td>{{ line.label }}</td>
@@ -293,6 +404,36 @@
         Los aranceles dependen del producto y el origen: muchos bienes del Mercosur pagan 0%. Ajustá
         los porcentajes según tu caso o consultá a tu despachante.
       </p>
+      <h2>Tipo de producto: IVA, trámites y prohibidos</h2>
+      <p>
+        Elegí el <strong>tipo de producto</strong> para ajustar el IVA y ver si necesitás trámites:
+      </p>
+      <ul>
+        <li>
+          <strong>No pagan IVA:</strong> libros, diarios y revistas están exentos. Los
+          <strong>medicamentos</strong> pagan la tasa mínima del 10%.
+        </li>
+        <li>
+          <strong>Pagan IVA 22%:</strong> el resto de los bienes (electrónica, ropa, juguetes, etc.).
+        </li>
+        <li>
+          <strong>Requieren trámites adicionales:</strong> celulares y equipos con radiofrecuencia,
+          drones y GPS necesitan homologación de <strong>URSEC</strong> (vía VUCE); medicamentos,
+          suplementos, cosméticos y productos médicos pasan por el <strong>MSP</strong>; semillas,
+          plantas, fertilizantes y alimentos por el <strong>MGAP</strong>; armas y réplicas por el
+          Servicio de Material y Armamento del Ejército.
+        </li>
+        <li>
+          <strong>Prohibidos por courier:</strong> vaporizadores y cigarrillos electrónicos,
+          pirotecnia, inflamables, baterías sueltas y power banks, dinero en efectivo y sustancias
+          controladas. Bebidas alcohólicas, tabaco, perfumería y vehículos pagan IMESI y solo
+          ingresan por importación formal (régimen general).
+        </li>
+      </ul>
+      <p>
+        Las listas son orientativas y <strong>no taxativas</strong>: pueden variar según la cantidad,
+        el uso y la normativa vigente. Confirmá siempre con Aduanas y el organismo correspondiente.
+      </p>
     </template>
 
     <template #disclaimer>
@@ -310,6 +451,12 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { courierImport, generalImport } from '~/utils/importTax'
+import {
+  IMPORT_PRODUCT_TYPES,
+  productRegimeStatus,
+  productTypeById,
+  resolveProductTax,
+} from '~/utils/importProductTypes'
 import { ESTIMATOR_COURIERS, shippingCostUsd, type Courier } from '~/utils/courierShipping'
 import { formatUSD } from '~/utils/format'
 
@@ -323,6 +470,36 @@ const franchiseAvailable = ref(800)
 const arancelPct = ref(0)
 const tasaConsularPct = ref(5)
 const ivaPct = ref(22)
+const imesiPct = ref(0)
+
+// Product type drives the IVA rate, IMESI applicability and which agencies must
+// authorize the shipment. `general` (the default) reproduces the prior behaviour.
+const productTypeId = ref('general')
+const productType = computed(() => productTypeById(productTypeId.value))
+const productTax = computed(() => resolveProductTax(productType.value))
+const regimeStatus = computed(() => productRegimeStatus(productType.value, regime.value))
+const showImesiField = computed(() => regime.value === 'general' && productType.value.imesi === true)
+
+// Keep the (still editable) IVA field in sync with the chosen product type.
+watch(
+  productTax,
+  tax => {
+    ivaPct.value = tax.ivaPct
+  },
+  { immediate: true }
+)
+// Reset the IMESI field when a category that does not levy IMESI is selected, so a
+// stale rate never lingers in the (now hidden) field.
+watch(showImesiField, on => {
+  if (!on) imesiPct.value = 0
+})
+
+const ORGANISM_LABEL: Record<string, string> = {
+  MSP: 'MSP — Salud Pública',
+  URSEC: 'URSEC (VUCE)',
+  MGAP: 'MGAP — Agricultura',
+  SMA: 'Material y Armamento (Ejército)',
+}
 
 // Courier shipping-by-weight — only couriers with a published flat per-kg are offered here.
 // Rates come from /api/couriers (daily-scraped, freshest), falling back to the static seed.
@@ -377,6 +554,15 @@ const sources = [
     label: 'MEF — Preguntas frecuentes sobre el régimen de envíos postales (franquicias)',
     url: 'https://www.gub.uy/ministerio-economia-finanzas/comunicacion/noticias/guia-preguntas-frecuentes-sobre-regimen-envios-postales-franquicias',
   },
+  {
+    label: 'Aduanas — Mercaderías controladas por otros organismos',
+    url: 'https://www.aduanas.gub.uy/innovaportal/v/25358/15/innova.front/',
+  },
+  {
+    label: 'Aduanas — ¿Qué mercadería no puedo traer bajo encomiendas postales?',
+    url: 'https://www.aduanas.gub.uy/innovaportal/v/25107/3/innova.front/que-mercaderia-no-puedo-traer-bajo-el-regimen-de-encomiendas-postales-internacionales.html',
+  },
+  { label: 'VUCE / URSEC — Homologación de equipos de radiofrecuencia', url: 'https://vuce.gub.uy' },
   { label: 'DGI — IVA e impuestos', url: 'https://www.dgi.gub.uy' },
 ]
 
@@ -388,6 +574,7 @@ const result = computed(() =>
         origin: origin.value,
         useFranchise: useFranchise.value,
         franchiseAvailable: franchiseAvailable.value || 0,
+        ivaPct: productTax.value.ivaPct,
       })
     : generalImport({
         value: value.value || 0,
@@ -396,6 +583,7 @@ const result = computed(() =>
         arancelPct: arancelPct.value || 0,
         tasaConsularPct: tasaConsularPct.value || 0,
         ivaPct: ivaPct.value || 0,
+        imesiPct: imesiPct.value || 0,
       })
 )
 
@@ -428,6 +616,18 @@ const faq = [
     a: 'No en el régimen courier (compra online): el IVA y la tasa única se calculan siempre sobre el costo interno del producto (el valor de la factura del vendedor), nunca sobre el flete del courier. El envío es un costo aparte que se muestra explícito y se suma al total. Distinto es el régimen general de importación formal, donde el flete sí integra el valor CIF sobre el que se calcula el IVA.',
   },
   {
+    q: '¿Qué productos no pagan IVA al importar?',
+    a: 'Los libros, diarios y revistas están exentos de IVA. Los medicamentos pagan la tasa mínima del 10% (y requieren autorización del MSP). El resto de los bienes paga el IVA general del 22%. En el régimen courier, además, los envíos desde EE.UU. de hasta US$ 200 quedan exonerados de IVA por el acuerdo TIFA, cualquiera sea el producto.',
+  },
+  {
+    q: '¿Qué productos requieren trámites adicionales para importar?',
+    a: 'Los celulares y equipos que emiten radiofrecuencia (también routers, drones y GPS) requieren homologación de URSEC, que se gestiona en la VUCE. Los medicamentos, suplementos, cosméticos y productos médicos pasan por el Ministerio de Salud Pública (MSP). Las semillas, plantas, fertilizantes y alimentos requieren autorización del MGAP. Las armas y réplicas (airsoft) se tramitan ante el Servicio de Material y Armamento del Ejército.',
+  },
+  {
+    q: '¿Qué productos están prohibidos por courier?',
+    a: 'No pueden importarse por encomiendas postales: vaporizadores y cigarrillos electrónicos, pirotecnia y explosivos, líquidos inflamables, baterías sueltas y power banks (restricción aérea), dinero en efectivo, sustancias controladas y pornografía. Bebidas alcohólicas, tabaco, perfumería y vehículos pagan IMESI y solo ingresan por importación formal (régimen general), no como envío personal.',
+  },
+  {
     q: '¿Las tarifas de courier por peso son oficiales?',
     a: 'No. Son valores de referencia (verificados en junio de 2026) para estimar el flete según el peso. Cada courier (Gripper, Envía Mi Compra, Casilla Mía, Punto Mío, etc.) tiene su propia tarifa por kilo y escalas por peso; ajustá el valor por kg al de tu courier o mirá la comparativa de couriers para una estimación más precisa.',
   },
@@ -436,3 +636,12 @@ const faq = [
 
 <!-- All layout primitives (seg-toggle, result-grid, tool-info-box,
      breakdown-table…) are shared from ToolShell, namespaced under .tool-page. -->
+
+<style scoped>
+/* Prohibited / not-allowed product: the estimate stays visible but dimmed so it
+   reads as informational, not actionable. */
+.result-blocked {
+  opacity: 0.55;
+  filter: grayscale(0.4);
+}
+</style>

--- a/app/tests/unit/importProductTypes.test.ts
+++ b/app/tests/unit/importProductTypes.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest'
+import { courierImport, generalImport } from '../../utils/importTax'
+import {
+  IMPORT_PRODUCT_TYPES,
+  ivaPctFor,
+  productRegimeStatus,
+  productTypeById,
+  resolveProductTax,
+} from '../../utils/importProductTypes'
+
+describe('ivaPctFor', () => {
+  it('maps the IVA treatment to its numeric rate', () => {
+    expect(ivaPctFor('exento')).toBe(0)
+    expect(ivaPctFor('minima')).toBe(10)
+    expect(ivaPctFor('basica')).toBe(22)
+  })
+})
+
+describe('IMPORT_PRODUCT_TYPES catalog', () => {
+  it('has unique ids', () => {
+    const ids = IMPORT_PRODUCT_TYPES.map(t => t.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('every type has a label and an icon', () => {
+    for (const t of IMPORT_PRODUCT_TYPES) {
+      expect(t.label.length).toBeGreaterThan(0)
+      expect(t.icon).toMatch(/^mdi-/)
+    }
+  })
+
+  it('exposes a "general" default that is the current (22%, no procedures, allowed) behavior', () => {
+    const general = productTypeById('general')
+    expect(general.iva).toBe('basica')
+    expect(general.imesi ?? false).toBe(false)
+    expect(general.prohibited ?? false).toBe(false)
+    expect(general.courierProhibited ?? false).toBe(false)
+    expect(general.procedures ?? []).toHaveLength(0)
+  })
+
+  it('books are IVA-exempt with no procedures', () => {
+    const libros = productTypeById('libros')
+    expect(libros.iva).toBe('exento')
+    expect(libros.procedures ?? []).toHaveLength(0)
+  })
+
+  it('medicines pay the 10% minima rate and require an MSP procedure', () => {
+    const med = productTypeById('medicamentos')
+    expect(med.iva).toBe('minima')
+    expect(med.procedures?.some(p => p.organism === 'MSP')).toBe(true)
+  })
+
+  it('radiofrequency goods require a URSEC procedure', () => {
+    const rf = productTypeById('radiofrecuencia')
+    expect(rf.procedures?.some(p => p.organism === 'URSEC')).toBe(true)
+  })
+
+  it('alcohol/tobacco applies IMESI and cannot enter via courier', () => {
+    const at = productTypeById('alcohol_tabaco')
+    expect(at.imesi).toBe(true)
+    expect(at.courierProhibited).toBe(true)
+  })
+
+  it('the prohibited category is flagged prohibited in both regimes', () => {
+    const p = productTypeById('prohibidos')
+    expect(p.prohibited).toBe(true)
+  })
+})
+
+describe('productTypeById', () => {
+  it('returns the matching type', () => {
+    expect(productTypeById('libros').id).toBe('libros')
+  })
+
+  it('falls back to "general" for an unknown id', () => {
+    expect(productTypeById('does-not-exist').id).toBe('general')
+  })
+})
+
+describe('productRegimeStatus', () => {
+  it('allows a general product in both regimes', () => {
+    expect(productRegimeStatus(productTypeById('general'), 'courier').blocked).toBe(false)
+    expect(productRegimeStatus(productTypeById('general'), 'general').blocked).toBe(false)
+  })
+
+  it('blocks a prohibited product in both regimes', () => {
+    const courier = productRegimeStatus(productTypeById('prohibidos'), 'courier')
+    const general = productRegimeStatus(productTypeById('prohibidos'), 'general')
+    expect(courier.blocked).toBe(true)
+    expect(general.blocked).toBe(true)
+    expect(courier.reason).toMatch(/prohib/i)
+  })
+
+  it('blocks a courier-prohibited product only in the courier regime', () => {
+    expect(productRegimeStatus(productTypeById('alcohol_tabaco'), 'courier').blocked).toBe(true)
+    expect(productRegimeStatus(productTypeById('alcohol_tabaco'), 'general').blocked).toBe(false)
+  })
+})
+
+describe('catalog feeds the import math', () => {
+  it('books (IVA exempt) pay no IVA on the franchised value via courier', () => {
+    const { ivaPct } = resolveProductTax(productTypeById('libros'))
+    const r = courierImport({ value: 150, origin: 'other', useFranchise: true, ivaPct })
+    expect(r.totalTax).toBe(0)
+  })
+
+  it('medicines pay the 10% rate on the franchised value via courier', () => {
+    const { ivaPct } = resolveProductTax(productTypeById('medicamentos'))
+    const r = courierImport({ value: 150, origin: 'other', useFranchise: true, ivaPct })
+    expect(r.totalTax).toBe(15) // 150 * 10%
+  })
+
+  it('general regime applies the category IMESI when it is supplied', () => {
+    const r = generalImport({
+      value: 1000,
+      tasaConsularPct: 0,
+      imesiPct: 20,
+      ivaPct: ivaPctFor(productTypeById('alcohol_tabaco').iva),
+    })
+    // IMESI 200, IVA base 1200, IVA 264, total 464
+    expect(r.totalTax).toBe(464)
+  })
+})
+
+describe('resolveProductTax', () => {
+  it('resolves the IVA rate and IMESI applicability of a category', () => {
+    expect(resolveProductTax(productTypeById('libros'))).toEqual({
+      ivaPct: 0,
+      imesiApplies: false,
+    })
+    expect(resolveProductTax(productTypeById('medicamentos'))).toEqual({
+      ivaPct: 10,
+      imesiApplies: false,
+    })
+    expect(resolveProductTax(productTypeById('alcohol_tabaco'))).toEqual({
+      ivaPct: 22,
+      imesiApplies: true,
+    })
+  })
+})

--- a/app/utils/importProductTypes.ts
+++ b/app/utils/importProductTypes.ts
@@ -1,0 +1,261 @@
+// Product-type catalog for the Uruguay import calculator
+// (`pages/herramientas/calculadora-impuestos-importacion.vue`).
+//
+// Picking a product type clarifies, for each category, whether it pays IVA (and
+// at what rate), whether it needs procedures with other agencies (MSP, URSEC,
+// MGAP, SMA) and whether it is prohibited — and feeds those tax parameters into
+// the pure `importTax` math. PURE data + functions (no Vue/Nuxt runtime) so they
+// can be unit-tested in plain Node via vitest.
+//
+// These are ESTIMATORS / informational aids. The lists are non-exhaustive (Aduanas:
+// "de carácter no taxativo") and rules change; the page renders prominent
+// disclaimers and links to Aduanas/DGI/MSP/URSEC/MGAP. Verified 2026-06-19.
+//
+// Sources:
+//  - Aduanas — mercadería bajo encomiendas postales internacionales:
+//    https://www.aduanas.gub.uy/innovaportal/v/25107/3/innova.front/que-mercaderia-no-puedo-traer-bajo-el-regimen-de-encomiendas-postales-internacionales.html
+//  - Aduanas — mercaderías controladas por otros organismos:
+//    https://www.aduanas.gub.uy/innovaportal/v/25358/15/innova.front/
+//  - VUCE / URSEC (homologación de radiofrecuencia): https://vuce.gub.uy/
+//  - Gripper — envíos con restricciones: https://www.gripper.com.uy/restricciones
+
+/** IVA treatment of a product: `exento` 0%, `minima` 10%, `basica` 22%. */
+export type IvaTreatment = 'exento' | 'minima' | 'basica'
+
+/** Government agency that controls (authorizes) a category of imports. */
+export type Organism = 'MSP' | 'URSEC' | 'MGAP' | 'SMA'
+
+/** A required procedure with a controlling agency before the goods can clear. */
+export interface ImportProcedure {
+  organism: Organism
+  /** Short, human-readable explanation of the procedure. */
+  note: string
+  /** Where to do the procedure, when published. */
+  url?: string
+}
+
+/** A selectable product category with its tax + regulatory profile. */
+export interface ImportProductType {
+  id: string
+  /** Display label for the selector. */
+  label: string
+  /** mdi-* icon name. */
+  icon: string
+  /** IVA treatment (drives the IVA rate used by the calculation). */
+  iva: IvaTreatment
+  /** Whether IMESI applies (relevant in the general regime). */
+  imesi?: boolean
+  /** Procedures required with other agencies before clearing customs. */
+  procedures?: ImportProcedure[]
+  /** Prohibited outright (both regimes). */
+  prohibited?: boolean
+  /** Allowed under the formal regime but NOT via courier (IMESI goods, vehicles…). */
+  courierProhibited?: boolean
+  /** Extra clarification shown next to the category. */
+  note?: string
+}
+
+const IVA_RATE: Record<IvaTreatment, number> = { exento: 0, minima: 10, basica: 22 }
+
+/** Numeric IVA rate (%) for a treatment. */
+export function ivaPctFor(treatment: IvaTreatment): number {
+  return IVA_RATE[treatment]
+}
+
+const MSP_URL = 'https://www.gub.uy/ministerio-salud-publica/'
+const URSEC_URL = 'https://vuce.gub.uy/'
+const MGAP_URL = 'https://www.gub.uy/ministerio-ganaderia-agricultura-pesca/'
+const SMA_URL = 'https://www.ejercito.mil.uy/'
+
+/**
+ * Selectable product categories. `general` is the default and reproduces the
+ * calculator's current behaviour (IVA 22%, no procedures, allowed everywhere)
+ * so existing results are unchanged until the user picks a more specific type.
+ */
+export const IMPORT_PRODUCT_TYPES: ImportProductType[] = [
+  {
+    id: 'general',
+    label: 'General / otros',
+    icon: 'mdi-package-variant-closed',
+    iva: 'basica',
+  },
+  {
+    id: 'electronica',
+    label: 'Electrónica (sin radio): laptops, tablets, consolas',
+    icon: 'mdi-laptop',
+    iva: 'basica',
+  },
+  {
+    id: 'radiofrecuencia',
+    label: 'Celulares y equipos con radiofrecuencia, drones, GPS, routers',
+    icon: 'mdi-cellphone-wireless',
+    iva: 'basica',
+    procedures: [
+      {
+        organism: 'URSEC',
+        note: 'Homologación de equipos que emiten radiofrecuencia. Se gestiona en la VUCE a nombre del consignatario; varios couriers tramitan con el comprobante.',
+        url: URSEC_URL,
+      },
+    ],
+  },
+  {
+    id: 'ropa',
+    label: 'Ropa, calzado y accesorios',
+    icon: 'mdi-tshirt-crew',
+    iva: 'basica',
+  },
+  {
+    id: 'libros',
+    label: 'Libros y material impreso (diarios, revistas)',
+    icon: 'mdi-book-open-variant',
+    iva: 'exento',
+    note: 'Libros, diarios y revistas están exentos de IVA en Uruguay.',
+  },
+  {
+    id: 'juguetes',
+    label: 'Juguetes y hobby',
+    icon: 'mdi-toy-brick',
+    iva: 'basica',
+  },
+  {
+    id: 'medicamentos',
+    label: 'Medicamentos',
+    icon: 'mdi-pill',
+    iva: 'minima',
+    procedures: [
+      {
+        organism: 'MSP',
+        note: 'Requieren autorización del Ministerio de Salud Pública (receta / registro). Ingreso muy restringido por courier.',
+        url: MSP_URL,
+      },
+    ],
+    note: 'IVA mínima (10%). Sólo para uso personal y con autorización.',
+  },
+  {
+    id: 'suplementos',
+    label: 'Suplementos y vitaminas',
+    icon: 'mdi-nutrition',
+    iva: 'basica',
+    procedures: [
+      { organism: 'MSP', note: 'Suplementos, vitaminas y similares son controlados por el MSP.', url: MSP_URL },
+    ],
+  },
+  {
+    id: 'cosmeticos',
+    label: 'Cosméticos y perfumería',
+    icon: 'mdi-lipstick',
+    iva: 'basica',
+    imesi: true,
+    courierProhibited: true,
+    procedures: [
+      { organism: 'MSP', note: 'Cosméticos y productos de higiene son controlados por el MSP (sobre todo en cantidad).', url: MSP_URL },
+    ],
+    note: 'La perfumería paga IMESI y no ingresa como envío personal por courier.',
+  },
+  {
+    id: 'medicos',
+    label: 'Productos médicos y ópticos (lentes, tensiómetro)',
+    icon: 'mdi-medical-bag',
+    iva: 'basica',
+    procedures: [
+      {
+        organism: 'MSP',
+        note: 'Lentes, lentes de contacto, tensiómetros y dispositivos médicos requieren trámite ante el MSP.',
+        url: MSP_URL,
+      },
+    ],
+  },
+  {
+    id: 'alimentos',
+    label: 'Alimentos y comestibles',
+    icon: 'mdi-food-apple',
+    iva: 'basica',
+    procedures: [
+      { organism: 'MGAP', note: 'Productos de origen animal o vegetal: control sanitario del MGAP.', url: MGAP_URL },
+      { organism: 'MSP', note: 'Alimentos elaborados: control bromatológico / MSP.', url: MSP_URL },
+    ],
+    note: 'Ingreso limitado por courier (sólo snacks sellados, de marca, en cantidad acotada).',
+  },
+  {
+    id: 'agro',
+    label: 'Plantas, semillas y fertilizantes',
+    icon: 'mdi-sprout',
+    iva: 'basica',
+    procedures: [
+      { organism: 'MGAP', note: 'Semillas, plantas y fertilizantes requieren autorización fitosanitaria del MGAP.', url: MGAP_URL },
+    ],
+  },
+  {
+    id: 'alcohol_tabaco',
+    label: 'Bebidas alcohólicas y tabaco',
+    icon: 'mdi-glass-wine',
+    iva: 'basica',
+    imesi: true,
+    courierProhibited: true,
+    note: 'Pagan IMESI y no ingresan como envío personal por courier.',
+  },
+  {
+    id: 'vehiculos',
+    label: 'Vehículos, motos y repuestos',
+    icon: 'mdi-car',
+    iva: 'basica',
+    imesi: true,
+    courierProhibited: true,
+    note: 'Los vehículos pagan IMESI. Los repuestos de moto usados están prohibidos.',
+  },
+  {
+    id: 'armas',
+    label: 'Armas, réplicas y airsoft',
+    icon: 'mdi-pistol',
+    iva: 'basica',
+    courierProhibited: true,
+    procedures: [
+      {
+        organism: 'SMA',
+        note: 'Armas y réplicas (airsoft con punta naranja) requieren trámite ante el Servicio de Material y Armamento del Ejército.',
+        url: SMA_URL,
+      },
+    ],
+  },
+  {
+    id: 'prohibidos',
+    label: 'Prohibidos: vaper/cigarrillo electrónico, pirotecnia, inflamables, baterías sueltas, drogas',
+    icon: 'mdi-cancel',
+    iva: 'basica',
+    prohibited: true,
+    note: 'No pueden importarse por encomiendas postales / courier.',
+  },
+]
+
+/** Look up a category by id; falls back to the `general` default for unknown ids. */
+export function productTypeById(id: string): ImportProductType {
+  return IMPORT_PRODUCT_TYPES.find(t => t.id === id) ?? IMPORT_PRODUCT_TYPES[0]!
+}
+
+/** Import regime the calculator operates in. */
+export type ImportRegime = 'courier' | 'general'
+
+/** Whether a category can be imported under a regime, with the blocking reason. */
+export function productRegimeStatus(
+  type: ImportProductType,
+  regime: ImportRegime
+): { blocked: boolean; reason?: string } {
+  if (type.prohibited) {
+    return { blocked: true, reason: 'Producto prohibido: no puede importarse.' }
+  }
+  if (regime === 'courier' && type.courierProhibited) {
+    return {
+      blocked: true,
+      reason: 'No ingresa por courier / encomiendas postales. Requiere importación formal (régimen general).',
+    }
+  }
+  return { blocked: false }
+}
+
+/** Resolve the tax parameters a category contributes to the calculation. */
+export function resolveProductTax(type: ImportProductType): {
+  ivaPct: number
+  imesiApplies: boolean
+} {
+  return { ivaPct: ivaPctFor(type.iva), imesiApplies: type.imesi ?? false }
+}

--- a/docs/superpowers/specs/2026-06-19-import-tool-product-type-design.md
+++ b/docs/superpowers/specs/2026-06-19-import-tool-product-type-design.md
@@ -1,0 +1,154 @@
+# Tipo de producto en la calculadora de impuestos de importación
+
+**Fecha:** 2026-06-19
+**Herramienta:** `app/pages/herramientas/calculadora-impuestos-importacion.vue`
+
+## Objetivo
+
+Permitir elegir el **tipo de producto** en la calculadora de importación, aclarando
+para cada categoría:
+
+- cuáles **no pagan IVA** (exentos),
+- cuáles **sí pagan** (y a qué tasa: 22% básica / 10% mínima),
+- cuáles **requieren trámites adicionales** (MSP / URSEC / MGAP / SMA),
+- cuáles están **prohibidos** por el régimen.
+
+La categoría además **ajusta el cálculo** (IVA según producto, IMESI en régimen
+general), no solo informa. Aplica a **ambos regímenes** (courier y general).
+
+## Alcance (decidido en brainstorming)
+
+- **Informar + ajustar cálculo.** La categoría cambia los números; no se suma costo
+  de trámite (ej. tasa URSEC/VUCE) al landed cost.
+- **Ambos regímenes:** courier (compra online) y general.
+- **Prohibidos:** se muestra aviso prominente pero el estimado sigue visible
+  (atenuado) para que el usuario vea la math y el motivo.
+- **IMESI:** campo editable (no hardcodeado). Las tasas IMESI varían de 0 a 100%+
+  según el producto; prefijar un único número engañaría. La categoría solo decide
+  si el campo IMESI **aparece** (régimen general).
+
+## Arquitectura
+
+Patrón data-driven, espejo de `courierShipping.ts` / `importTax.ts`:
+
+### 1. Catálogo de datos — `app/utils/importProductTypes.ts`
+
+Funciones/datos puros (sin runtime Vue), unit-testables.
+
+```ts
+export type IvaTreatment = 'exento' | 'minima' | 'basica' // 0 / 10 / 22
+export type Organism = 'MSP' | 'URSEC' | 'MGAP' | 'SMA'
+
+export interface ImportProcedure {
+  organism: Organism
+  note: string
+  url?: string
+}
+
+export interface ImportProductType {
+  id: string
+  label: string
+  icon: string                  // mdi-*
+  iva: IvaTreatment
+  imesi?: boolean               // IMESI aplica (régimen general)
+  procedures?: ImportProcedure[]
+  prohibited?: boolean          // prohibido en ambos regímenes
+  courierProhibited?: boolean   // OK formal, NO por courier (bienes IMESI, etc.)
+  note?: string
+}
+
+export const IMPORT_PRODUCT_TYPES: ImportProductType[] = [ /* ver catálogo */ ]
+
+/** Mapea tratamiento IVA → tasa numérica. */
+export function ivaPctFor(t: IvaTreatment): number // exento 0, minima 10, basica 22
+
+/** Resuelve parámetros fiscales de una categoría. */
+export function resolveProductTax(type: ImportProductType): {
+  ivaPct: number
+  imesiApplies: boolean
+}
+
+export function productTypeById(id: string): ImportProductType
+```
+
+JSDoc en cabecera con fecha de verificación (2026-06-19), aclaración de que son
+estimadores y fuentes (Aduanas, MSP, URSEC/VUCE, MGAP, DGI).
+
+### 2. Catálogo de categorías
+
+| id | Categoría | IVA | IMESI | Trámite | Courier |
+|---|---|---|---|---|---|
+| `general` | General / otros (default) | básica 22% | — | — | ✅ |
+| `electronica` | Electrónica (sin radio): laptops, tablets, consolas | 22% | — | — | ✅ |
+| `radiofrecuencia` | Celulares / radiofrecuencia, drones, GPS, routers | 22% | — | **URSEC** (VUCE) | ✅ c/permiso |
+| `ropa` | Ropa, calzado y accesorios | 22% | — | — | ✅ |
+| `libros` | Libros y material impreso (diarios, revistas) | **exento 0%** | — | — | ✅ |
+| `juguetes` | Juguetes / hobby | 22% | — | — | ✅ |
+| `medicamentos` | Medicamentos | **mínima 10%** | — | **MSP** (receta) | ⚠️ restringido |
+| `suplementos` | Suplementos y vitaminas | 22% | — | **MSP** | ⚠️ |
+| `cosmeticos` | Cosméticos y perfumería | 22% | **sí** | MSP (cantidad) | ❌ courier |
+| `medicos` | Productos médicos / ópticos (lentes, tensiómetro) | 22% | — | **MSP** | ✅ c/trámite |
+| `alimentos` | Alimentos / comestibles | 22% | — | **MGAP/MSP** | ⚠️ limitado |
+| `agro` | Plantas, semillas, fertilizantes | 22% | — | **MGAP** | ⚠️ |
+| `alcohol_tabaco` | Bebidas alcohólicas / tabaco | 22% | **sí** | — | ❌ courier |
+| `vehiculos` | Vehículos, motos y repuestos | 22% | **sí** | — | ❌ courier (repuestos moto usados prohibidos) |
+| `armas` | Armas, réplicas, airsoft | 22% | — | **SMA (Ejército)** | ❌ courier |
+| `prohibidos` | Prohibidos: vaper/cig. electrónico, pirotecnia, inflamables, baterías sueltas/power banks, drogas | — | — | — | ❌ **prohibido** |
+
+Notas de exactitud:
+- `iva` es el tratamiento general DGI; el régimen courier hoy grava la franquicia
+  al 22% salvo excepción TIFA. Con tipo de producto, libros → 0% y medicamentos →
+  10% sobre la porción gravada.
+- IMESI no se hardcodea: la categoría solo marca que aplica.
+- Lista no taxativa (Aduanas: "de carácter no taxativo"); disclaimers lo aclaran.
+
+### 3. Integración con el cálculo
+
+- `courierImport` ya acepta `ivaPct`. La página pasa `ivaPctFor(categoria.iva)`.
+  La excepción USA-TIFA (≤ US$200) sigue forzando IVA 0% por encima del producto.
+- `generalImport` ya acepta `ivaPct` e `imesiPct`. La página pasa el IVA de la
+  categoría; si `imesi`, muestra el campo IMESI (hoy oculto) prefijado con un
+  placeholder editable + hint "varía según producto".
+- `prohibited` (ambos) o `courierProhibited` (en régimen courier) → `VAlert` roja;
+  el resultado se sigue renderizando atenuado.
+
+### 4. UI (`calculadora-impuestos-importacion.vue`)
+
+- `VSelect` "Tipo de producto" cerca del tope, visible en ambos regímenes.
+  Default `general` ⇒ comportamiento idéntico al actual (backward-compat).
+- Panel de estado bajo el selector:
+  - chip de IVA (Exento / 10% / 22%),
+  - chips de trámite por organismo (con link a VUCE / MSP),
+  - `VAlert` de prohibición cuando corresponde al régimen activo.
+- Régimen general: el campo IMESI (%) aparece solo si la categoría lo marca.
+
+### 5. Contenido y fuentes
+
+- Actualizar `#content`, `faq`, `#disclaimer` para explicar tipos de producto,
+  trámites y prohibiciones.
+- Ampliar `sources` con MSP, URSEC/VUCE, MGAP y la página de Aduanas de
+  mercaderías controladas / prohibidas bajo encomiendas postales.
+
+### 6. Tests
+
+- `app/tests/unit/importProductTypes.test.ts`: `ivaPctFor`, `resolveProductTax`,
+  integridad del catálogo (ids únicos, flags coherentes).
+- Ampliar `app/tests/unit/importTax.test.ts`: courier con IVA exento (libros) y
+  10% (medicamentos); general con IMESI activo; TIFA sigue forzando 0%.
+
+## Fuentes
+
+- Aduanas — ¿Qué mercadería no puedo traer bajo encomiendas postales?:
+  https://www.aduanas.gub.uy/innovaportal/v/25107/3/innova.front/que-mercaderia-no-puedo-traer-bajo-el-regimen-de-encomiendas-postales-internacionales.html
+- Aduanas — Mercaderías controladas por otros organismos:
+  https://www.aduanas.gub.uy/innovaportal/v/25358/15/innova.front/
+- VUCE / URSEC (homologación radiofrecuencia): https://vuce.gub.uy/
+- Gripper — Envíos con restricciones: https://www.gripper.com.uy/restricciones
+- FedEx Uruguay — Artículos prohibidos: https://www.fedex.com/es-uy/shipping/prohibited-items.html
+- DGI — IVA e impuestos: https://www.dgi.gub.uy
+
+## Fuera de alcance (YAGNI)
+
+- Búsqueda por código NCM/HS (miles de partidas).
+- Cálculo de tasas IMESI exactas por producto.
+- Costeo del trámite (tasa URSEC/VUCE/MSP) en el landed cost.


### PR DESCRIPTION
## Qué hace

Agrega un selector **Tipo de producto** a la calculadora de impuestos de importación. Cada categoría aclara su tratamiento de IVA, si requiere trámites con otros organismos y si está prohibida — y ajusta el cálculo en ambos regímenes (courier y general).

## Cambios

- **Catálogo data-driven** `app/utils/importProductTypes.ts` (puro, unit-tested): 16 categorías + `ivaPctFor`, `resolveProductTax`, `productRegimeStatus`.
- **Courier:** el IVA de la categoría grava la franquicia (libros 0%, medicamentos 10%); la exoneración USA-TIFA ≤US$200 sigue prevaleciendo.
- **General:** IVA por categoría + campo IMESI editable que aparece solo cuando corresponde.
- **Prohibidos / no-courier:** alerta bloqueante; el estimado queda visible pero atenuado. Default `General / otros` preserva el comportamiento previo.
- Chips de estado (IVA / IMESI / links de trámite), contenido, FAQ y fuentes actualizados (listas de Aduanas, VUCE/URSEC).

## Investigación

Categorías y reglas derivadas de fuentes oficiales: [Aduanas — encomiendas postales](https://www.aduanas.gub.uy/innovaportal/v/25107/3/innova.front/que-mercaderia-no-puedo-traer-bajo-el-regimen-de-encomiendas-postales-internacionales.html), [Aduanas — mercaderías controladas](https://www.aduanas.gub.uy/innovaportal/v/25358/15/innova.front/), VUCE/URSEC, Gripper restricciones. Son estimadores con disclaimers (listas no taxativas).

## Verificación

- TDD: 18 tests nuevos del catálogo. Suite completa **339/339 pass**. Lint + typecheck limpios.
- Probado en navegador (dev): libros→exento (IVA $0), bebidas/tabaco courier→bloqueo+IMESI+atenuado, mismo en general→bloqueo se limpia + aparece IMESI. 0 errores de consola.

Spec: `docs/superpowers/specs/2026-06-19-import-tool-product-type-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)