### PR TITLE
docs(import-tool): list MSP, MGAP and Ejército in sources

### DIFF
--- a/app/pages/herramientas/calculadora-impuestos-importacion.vue
+++ b/app/pages/herramientas/calculadora-impuestos-importacion.vue
@@ -563,6 +563,9 @@ const sources = [
     url: 'https://www.aduanas.gub.uy/innovaportal/v/25107/3/innova.front/que-mercaderia-no-puedo-traer-bajo-el-regimen-de-encomiendas-postales-internacionales.html',
   },
   { label: 'VUCE / URSEC — Homologación de equipos de radiofrecuencia', url: 'https://vuce.gub.uy' },
+  { label: 'MSP — Medicamentos, suplementos, cosméticos y productos médicos', url: 'https://www.gub.uy/ministerio-salud-publica/' },
+  { label: 'MGAP — Plantas, semillas, fertilizantes y alimentos', url: 'https://www.gub.uy/ministerio-ganaderia-agricultura-pesca/' },
+  { label: 'Ejército — Servicio de Material y Armamento (armas y réplicas)', url: 'https://www.ejercito.mil.uy' },
   { label: 'DGI — IVA e impuestos', url: 'https://www.dgi.gub.uy' },
 ]
 


### PR DESCRIPTION
Adds MSP, MGAP and Ejército (Servicio de Material y Armamento) to the visible **Fuentes y referencias** list of the import calculator.

The product-type procedure chips already linked these agencies; this surfaces every referenced organism (MSP / MGAP / SMA) as a citable source alongside Aduanas, VUCE/URSEC and DGI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)