### PR TITLE
feat(bcu): SOAP cotizaciones source + history backfill

### DIFF
--- a/bcu_backfill.ts
+++ b/bcu_backfill.ts
@@ -1,0 +1,112 @@
+import moment from "moment-timezone";
+import { buildUpsertOps, chunkDateRange, detectGaps, type DateGap } from "./classes/bcu_backfill";
+import { fetchCotizaciones, type BcuQuote } from "./classes/bcu_soap";
+import { MongooseServer, Schema } from "./classes/database";
+
+/**
+ * Backfill missing BCU history in the `cambio-uy` collection from the BCU SOAP
+ * cotizaciones service. Idempotent (upsert by {origin,date,code,type}).
+ *
+ *   npm run bcu_backfill -- --dry                 # detect gaps, print plan, no writes
+ *   npm run bcu_backfill                          # fill auto-detected gaps
+ *   npm run bcu_backfill -- --from 2026-03-13 --to 2026-06-15   # explicit range
+ *   npm run bcu_backfill -- --min-gap 4           # gap threshold in days (default 4)
+ */
+
+const ORIGIN = "bcu";
+
+const flag = (name: string): boolean => process.argv.includes(name);
+const opt = (name: string): string | undefined => {
+  const i = process.argv.indexOf(name);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+};
+const fmt = (d: Date): string => moment.tz(d, "America/Montevideo").format("YYYY-MM-DD");
+const mvd = (ymd: string): Date => moment.tz(ymd, "America/Montevideo").startOf("day").toDate();
+
+function getDb(): MongooseServer {
+  return MongooseServer.getInstance(
+    "cambio-uy",
+    new Schema({
+      bcu: { type: String },
+      origin: { type: String },
+      code: { type: String },
+      type: { type: String },
+      name: { type: String },
+      buy: { type: Number },
+      sell: { type: Number },
+      date: { type: Date },
+    })
+  );
+}
+
+async function main() {
+  const dry = flag("--dry");
+  const minGap = Number(opt("--min-gap") ?? 4);
+  const fromArg = opt("--from");
+  const toArg = opt("--to");
+
+  await MongooseServer.startConnectionPromise();
+  const db = getDb();
+
+  const today = moment.tz("America/Montevideo").startOf("day").toDate();
+
+  let spans: DateGap[];
+  if (fromArg && toArg) {
+    spans = [{ from: mvd(fromArg), to: mvd(toArg) }];
+  } else {
+    const dates: Date[] = await db.getModel().distinct("date", { origin: ORIGIN });
+    console.log(`Existing BCU data points: ${dates.length}`);
+    spans = detectGaps(dates, today, minGap);
+  }
+
+  if (spans.length === 0) {
+    console.log("No gaps detected. Nothing to backfill.");
+    process.exit(0);
+  }
+
+  console.log(`\nSpans to fill (${spans.length}):`);
+  for (const s of spans) console.log(`  ${fmt(s.from)} → ${fmt(s.to)}`);
+
+  // The SOAP service caps the date range per request, so split each span into windows.
+  const MAX_RANGE_DAYS = 30;
+  const allQuotes: BcuQuote[] = [];
+  for (const s of spans) {
+    for (const c of chunkDateRange(s.from, s.to, MAX_RANGE_DAYS)) {
+      const q = await fetchCotizaciones(c.from, c.to);
+      console.log(`  fetched ${q.length} quotes for ${fmt(c.from)} → ${fmt(c.to)}`);
+      allQuotes.push(...q);
+    }
+  }
+
+  const ops = buildUpsertOps(allQuotes, ORIGIN);
+
+  const byCur = new Map<string, number>();
+  for (const op of ops) {
+    const k = op.filter.type ? `${op.filter.code}/${op.filter.type}` : op.filter.code;
+    byCur.set(k, (byCur.get(k) ?? 0) + 1);
+  }
+  console.log(`\nPlanned upserts: ${ops.length}`);
+  for (const [k, n] of [...byCur].sort()) console.log(`  ${k}: ${n}`);
+  console.log(
+    "Sample:",
+    ops.slice(0, 3).map((o) => ({ date: fmt(o.filter.date), code: o.filter.code, type: o.filter.type, ...o.update }))
+  );
+
+  if (dry) {
+    console.log("\n[DRY RUN] No writes performed.");
+    process.exit(0);
+  }
+
+  const res = await db.bulkUpsert(ops);
+  console.log("\nbulkWrite result:", {
+    upserted: (res as any).upsertedCount,
+    modified: (res as any).modifiedCount,
+    matched: (res as any).matchedCount,
+  });
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/classes/bcu_backfill.ts
+++ b/classes/bcu_backfill.ts
@@ -1,0 +1,84 @@
+import moment from "moment-timezone";
+import type { BcuQuote } from "./bcu_soap";
+
+/**
+ * Pure planning helpers for the BCU history backfill. No DB or network here so they
+ * can be unit-tested directly; the runner (`bcu_backfill.ts`) wires these to Mongo
+ * and the SOAP client.
+ */
+
+export interface DateGap {
+  from: Date;
+  to: Date;
+}
+
+export interface UpsertOp {
+  filter: { origin: string; date: Date; code: string; type: string };
+  update: { name: string; buy: number; sell: number };
+}
+
+const startOfDay = (d: Date): Date => moment.tz(d, "America/Montevideo").startOf("day").toDate();
+const addDays = (d: Date, n: number): Date => moment.tz(d, "America/Montevideo").startOf("day").add(n, "day").toDate();
+const dayDiff = (a: Date, b: Date): number =>
+  moment.tz(b, "America/Montevideo").startOf("day").diff(moment.tz(a, "America/Montevideo").startOf("day"), "days");
+
+/**
+ * Find missing spans in a series of existing data dates. A gap is a jump larger than
+ * `minGapDays` between consecutive dates (so normal weekend/holiday gaps are ignored),
+ * plus a trailing gap from the last date up to `today`. Each span is inclusive and
+ * already trimmed to the missing days.
+ */
+export function detectGaps(existingDates: Date[], today: Date, minGapDays = 4): DateGap[] {
+  if (existingDates.length === 0) return [];
+  const sorted = [...new Set(existingDates.map((d) => startOfDay(d).getTime()))]
+    .sort((a, b) => a - b)
+    .map((t) => new Date(t));
+
+  const gaps: DateGap[] = [];
+  for (let i = 1; i < sorted.length; i++) {
+    if (dayDiff(sorted[i - 1], sorted[i]) > minGapDays) {
+      gaps.push({ from: addDays(sorted[i - 1], 1), to: addDays(sorted[i], -1) });
+    }
+  }
+
+  const last = sorted[sorted.length - 1];
+  if (dayDiff(last, today) > minGapDays) {
+    gaps.push({ from: addDays(last, 1), to: startOfDay(today) });
+  }
+  return gaps;
+}
+
+/**
+ * Split [from, to] (inclusive) into contiguous, non-overlapping windows of at most
+ * `maxDays` span each. The BCU SOAP service rejects ranges beyond a fixed limit
+ * ("Rango de fechas excede lo permitido"), so long backfills must be chunked.
+ */
+export function chunkDateRange(from: Date, to: Date, maxDays = 30): DateGap[] {
+  const chunks: DateGap[] = [];
+  let start = startOfDay(from);
+  const end = startOfDay(to);
+  while (start.getTime() <= end.getTime()) {
+    const candidate = addDays(start, maxDays);
+    const chunkTo = candidate.getTime() <= end.getTime() ? candidate : end;
+    chunks.push({ from: start, to: chunkTo });
+    start = addDays(chunkTo, 1);
+  }
+  return chunks;
+}
+
+/**
+ * Turn normalized quotes into idempotent bulk-upsert operations keyed by
+ * {origin, date, code, type}. Duplicate keys collapse to the last value.
+ */
+export function buildUpsertOps(quotes: BcuQuote[], origin = "bcu"): UpsertOp[] {
+  const o = origin.toLowerCase();
+  const byKey = new Map<string, UpsertOp>();
+  for (const q of quotes) {
+    const key = `${o}|${q.date.getTime()}|${q.code}|${q.type}`;
+    byKey.set(key, {
+      filter: { origin: o, date: q.date, code: q.code, type: q.type },
+      update: { name: q.name, buy: q.buy, sell: q.sell },
+    });
+  }
+  return [...byKey.values()];
+}

--- a/classes/bcu_soap.ts
+++ b/classes/bcu_soap.ts
@@ -1,0 +1,151 @@
+import moment from "moment-timezone";
+import * as soap from "soap";
+
+/**
+ * Client + pure helpers for the BCU "cotizaciones" SOAP web service.
+ *
+ * Endpoint: awsbcucotizaciones (GeneXus). Unlike the HTML page the public site
+ * scrapes, this service supports historical date-range queries, so it doubles as
+ * the live source for the BCU scraper AND the backfill of past gaps.
+ *
+ * Response shape (verified against the live service):
+ *   Salida.respuestastatus { status, codigoerror, mensaje }   // status "1" == ok
+ *   Salida.datoscotizaciones["datoscotizaciones.dato"][]       // array (or single object)
+ *     { Fecha, Moneda, Nombre, CodigoISO, Emisor, TCC, TCV, ArbAct, FormaArbitrar }
+ *   TCC == buy, TCV == sell.
+ */
+
+export const COTIZACIONES_WSDL =
+  "https://cotizaciones.bcu.gub.uy/wscotizaciones/servlet/awsbcucotizaciones?wsdl";
+
+export interface BcuConversion {
+  code: string;
+  type: string;
+}
+
+/**
+ * Maps the BCU `Nombre` field to our (code, type). Keys are the exact strings the
+ * service returns and mirror the legacy HTML scraper's `conversions` map, so SOAP
+ * rows merge into the same history series (same upsert key {origin,date,code,type}).
+ */
+export const BCU_CONVERSIONS: Record<string, BcuConversion> = {
+  "DLS. USA BILLETE": { code: "USD", type: "BILLETE" },
+  "DLS. USA CABLE": { code: "USD", type: "CABLE" },
+  "DLS.PROMED.FONDO": { code: "USD", type: "PROMED.FONDO" },
+  "PESO ARG.BILLETE": { code: "ARS", type: "BILLETE" },
+  "REAL BILLETE": { code: "BRL", type: "BILLETE" },
+  "UNIDAD INDEXADA": { code: "UI", type: "" },
+  "UNIDAD PREVISIONAL": { code: "UP", type: "" },
+  "UNIDAD REAJUSTAB": { code: "UR", type: "" },
+};
+
+/** Numeric Moneda codes to request — the set covered by BCU_CONVERSIONS. */
+export const BCU_MONEDA_CODES: number[] = [2225, 2224, 2230, 501, 1001, 9700, 9800, 9900];
+
+export interface BcuRawRow {
+  Fecha: string | Date;
+  Moneda: number;
+  Nombre: string;
+  CodigoISO?: string;
+  Emisor?: string;
+  TCC: number;
+  TCV: number;
+}
+
+export interface BcuQuote {
+  date: Date;
+  code: string;
+  type: string;
+  name: string;
+  buy: number;
+  sell: number;
+}
+
+/**
+ * Convert a BCU `Fecha` (UTC midnight of a business day) to the same Montevideo
+ * start-of-day Date the daily scraper stores. We read the UTC calendar Y-M-D first;
+ * interpreting the UTC-midnight instant directly in America/Montevideo would shift
+ * it to the previous day (off-by-one).
+ */
+export function toMontevideoDate(fecha: string | Date): Date {
+  const ymd = moment.utc(fecha).format("YYYY-MM-DD");
+  return moment.tz(ymd, "America/Montevideo").startOf("day").toDate();
+}
+
+/** Throw if the SOAP response status is not success ("1"). */
+export function assertOk(response: any): void {
+  const st = response?.Salida?.respuestastatus;
+  if (!st || String(st.status) !== "1") {
+    const msg = st?.mensaje || `status=${st?.status} codigoerror=${st?.codigoerror}`;
+    throw new Error(`BCU SOAP error: ${msg}`);
+  }
+}
+
+/** Pull the rows out of the nested response, normalizing single-object → array. */
+export function extractRows(response: any): BcuRawRow[] {
+  const dato = response?.Salida?.datoscotizaciones?.["datoscotizaciones.dato"];
+  if (!dato) return [];
+  return Array.isArray(dato) ? dato : [dato];
+}
+
+/** Map raw rows to BcuQuote, dropping unknown currencies and 0/0 quotes. */
+export function normalizeRows(
+  rows: BcuRawRow[],
+  conversions: Record<string, BcuConversion> = BCU_CONVERSIONS
+): BcuQuote[] {
+  const out: BcuQuote[] = [];
+  for (const row of rows) {
+    const conv = conversions[row.Nombre];
+    if (!conv) continue;
+    const buy = Number(row.TCC) || 0;
+    const sell = Number(row.TCV) || 0;
+    if (buy === 0 && sell === 0) continue;
+    out.push({
+      date: toMontevideoDate(row.Fecha),
+      code: conv.code,
+      type: conv.type,
+      name: row.Nombre,
+      buy,
+      sell,
+    });
+  }
+  return out;
+}
+
+/** assertOk + extractRows + normalizeRows. */
+export function parseCotizaciones(
+  response: any,
+  conversions: Record<string, BcuConversion> = BCU_CONVERSIONS
+): BcuQuote[] {
+  assertOk(response);
+  return normalizeRows(extractRows(response), conversions);
+}
+
+/**
+ * Call the live service for the given codes over [desde, hasta] (inclusive) and
+ * return normalized quotes. Dates are formatted as YYYY-MM-DD (xsd:date).
+ * A single call covers the whole range — the service returns every business day.
+ */
+export async function fetchCotizaciones(
+  desde: Date,
+  hasta: Date,
+  codes: number[] = BCU_MONEDA_CODES,
+  grupo = 0
+): Promise<BcuQuote[]> {
+  const client = await soap.createClientAsync(COTIZACIONES_WSDL);
+  const [result] = await client.ExecuteAsync({
+    Entrada: {
+      Moneda: { item: codes },
+      FechaDesde: moment.tz(desde, "America/Montevideo").format("YYYY-MM-DD"),
+      FechaHasta: moment.tz(hasta, "America/Montevideo").format("YYYY-MM-DD"),
+      Grupo: grupo,
+    },
+  });
+  return parseCotizaciones(result);
+}
+
+/** Today's cotizaciones (single-day range), for the live scraper path. */
+export async function fetchCurrentCotizaciones(codes: number[] = BCU_MONEDA_CODES): Promise<BcuQuote[]> {
+  const today = moment.tz("America/Montevideo").startOf("day").toDate();
+  return fetchCotizaciones(today, today, codes);
+}

--- a/classes/cambios/bcu.ts
+++ b/classes/cambios/bcu.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { load } from "cheerio";
 import { CambioObj } from "../../interfaces/Cambio";
+import { fetchCurrentCotizaciones } from "../bcu_soap";
 import { Cambio } from "../cambio";
 class CambioBCU extends Cambio {
   name = "Banco Central del Uruguay";
@@ -49,6 +50,27 @@ class CambioBCU extends Cambio {
   };
 
   async get_data(): Promise<CambioObj[]> {
+    // SOAP is the primary source: it's a stable API, immune to the HTML redesigns
+    // that have silently broken the scrape before. Fall back to the HTML page only
+    // if SOAP fails or returns nothing.
+    try {
+      const quotes = await fetchCurrentCotizaciones();
+      if (quotes.length > 0) {
+        return quotes.map((q) => ({
+          code: q.code,
+          type: q.type,
+          name: q.name,
+          buy: q.buy,
+          sell: q.sell,
+        }));
+      }
+    } catch (e) {
+      console.error("BCU SOAP failed, falling back to HTML scrape:", (e as Error).message);
+    }
+    return this.get_data_html();
+  }
+
+  async get_data_html(): Promise<CambioObj[]> {
     const web_data = await axios.get(this.website).then((res) => res.data);
     const $ = load(web_data);
     // 2025 redesign: rows live in tbody[id*='lstCotizaciones'] with class-based cells

--- a/docs/superpowers/specs/2026-06-23-bcu-soap-backfill-design.md
+++ b/docs/superpowers/specs/2026-06-23-bcu-soap-backfill-design.md
@@ -1,0 +1,150 @@
+# BCU SOAP Backfill + Scraper Hardening — Design
+
+**Date:** 2026-06-23
+**Status:** Approved
+**Repo:** root (`cambio-uruguay`) — backend only. The `app/` Nuxt project is **unchanged**; it reads `/evolution`, which reads the same Mongo collection this work writes to.
+
+## Problem
+
+The `/comparar` chart's "Banco Central del Uruguay" series shows a flat, straight green segment from ~mid-March to ~mid-June 2026. The line is Chart.js (`spanGaps: true`) connecting the last data point before the gap directly to the first point after it. The gap is real: no BCU history documents exist for those dates.
+
+Root cause: [`classes/cambios/bcu.ts`](../../../classes/cambios/bcu.ts) scrapes only the **current** BCU cotizaciones HTML page. BCU did a "2025 redesign" of that page; the CSS selectors broke, so the daily scrape saved zero BCU rows for the affected period. The selector was later fixed (`td.Moneda`), so data resumed — leaving a hole in the middle.
+
+## Goals
+
+1. **Backfill** the missing BCU history for all currencies BCU maps, using the BCU SOAP cotizaciones web service (supports historical date-range queries).
+2. **Harden** the scraper: make BCU SOAP the primary source going forward, with the existing HTML scrape as fallback, so a future HTML redesign can't silently blank the series again.
+
+## Non-goals
+
+- No changes to the `app/` Nuxt project.
+- No change to the evolution API, chart, or `spanGaps` behaviour.
+- No backfill of non-BCU houses.
+
+## Data model (existing, unchanged)
+
+History lives in the mongoose model `cambio-uy` (see [`classes/cambio.ts`](../../../classes/cambio.ts#L96)). One document per quote:
+
+```
+{ origin, date, code, type, name, buy, sell }
+```
+
+- `origin` for BCU = `"bcu"` (see [`classes/origins.ts`](../../../classes/origins.ts#L81)).
+- `date` = `moment.tz(d, "America/Montevideo").startOf("day").toDate()`.
+- Upsert key = `{ origin, date, code, type }` (see [`save()`](../../../classes/cambio.ts#L180)). **`type` must match the existing scraper's values exactly** so backfilled rows merge into the same series instead of creating parallel dupes.
+
+The evolution endpoint reads this collection by `{origin, code, [type], date range}` ([`cambioInfo.get_currency_evolution`](../../../classes/cambioInfo.ts#L151)).
+
+## Currency code map
+
+BCU SOAP identifies currencies by numeric `Moneda` codes. Map (mirrors the existing [`bcu.ts conversions`](../../../classes/cambios/bcu.ts#L16) so `code`/`type` align with already-stored docs):
+
+| BCU `Moneda` | BCU name          | `code` | `type`         |
+|--------------|-------------------|--------|----------------|
+| 2225         | USA BILLETE       | USD    | BILLETE        |
+| 2224         | USA CABLE         | USD    | CABLE          |
+| 2230         | USA PROMED. FONDO | USD    | PROMED.FONDO   |
+| 0501         | PESO ARG. BILLETE | ARS    | BILLETE        |
+| 1001         | REAL BILLETE      | BRL    | BILLETE        |
+| 9800         | UNIDAD INDEXADA   | UI     | "" (empty)     |
+| (lookup)     | UNIDAD REAJUSTAB  | UR     | "" (empty)     |
+| (lookup)     | UNIDAD PREVISIONAL| UP     | "" (empty)     |
+
+Codes 2225/2224/2230/0501/1001/9800 are confirmed from BCU's official code table
+(`https://www.bcu.gub.uy/Documents/cotizacion.txt`). UR/UP are not in the local-market
+file; their codes are resolved at implementation time via the `awsbcumonedas` SOAP
+operation (read-only probe). **If SOAP does not expose UR/UP, they are dropped from the
+backfill** and continue to be filled by the HTML scraper going forward — noted as a known
+limitation, not a blocker.
+
+## SOAP service
+
+- WSDL: `https://cotizaciones.bcu.gub.uy/wscotizaciones/servlet/awsbcucotizaciones?wsdl`
+- Operation: `Execute` with input `{ Moneda: int[], FechaDesde: date, FechaHasta: date, Grupo: byte }`.
+- Output: `respuestastatus { status, codigoerror, mensaje }` + `datoscotizaciones[]`, each
+  `{ Fecha, Moneda, Nombre, CodigoISO, Emisor, TCC, TCV, ArbAct, FormaArbitrar }`.
+- **`TCC` → `buy`, `TCV` → `sell`.**
+- A single call returns **all business days in the date range** for the requested codes — one call backfills the whole gap, not one call per day.
+- `Grupo`: `0` = todas las monedas. Exact value for the local market (0 vs 2) is confirmed
+  against the live service during the read-only probe before any write.
+
+## Components
+
+### 1. `classes/bcu_soap.ts` (new) — thin SOAP client
+
+- Wraps the `soap` npm package over the WSDL.
+- `getCotizaciones(codes: number[], desde: Date, hasta: Date, grupo?: number): Promise<BcuRow[]>`
+  returns normalized rows `{ date, code, type, name, buy, sell }`.
+- Validates `respuestastatus`; throws on `status`/`codigoerror` failure.
+- Skips rows where `buy === 0 && sell === 0`.
+- `getMonedas()` (optional) wraps `awsbcumonedas` for code discovery / UR-UP resolution.
+- Pure normalization logic (`mapRow`, `CODE_MAP`) is separated from the network call so it's unit-testable with a fixture SOAP response.
+
+### 2. Refactor `classes/cambios/bcu.ts` → SOAP-primary
+
+- `get_data()`: try SOAP for the current cotización (today / last cierre) → map → return `CambioObj[]`.
+- On SOAP throw or empty result → fall back to the existing cheerio HTML scrape (kept intact).
+- Output shape and `conversions` mapping unchanged → saved docs identical to today's.
+- Net effect: robust against **both** a BCU HTML redesign and a SOAP outage.
+
+### 3. `classes/bcu_backfill.ts` + `bcu_backfill.ts` runner (new) — one-off
+
+- Runner follows the repo convention: a top-level `ts-node` script, added to `package.json`
+  scripts as `"bcu_backfill": "ts-node bcu_backfill.ts"`.
+- Steps:
+  1. Connect Mongo via `MongooseServer.startConnectionPromise()` (URI from `MONGODB_URI`).
+  2. Determine date range: auto-detect the gap by scanning existing `bcu` docs (min/max +
+     missing span); `--from YYYY-MM-DD` / `--to YYYY-MM-DD` CLI args override.
+  3. One SOAP range call for all mapped codes.
+  4. Build upsert operations keyed by `{ origin: "bcu", date, code, type }`, value
+     `{ name, buy, sell }`, `date` normalized to Montevideo `startOf("day")`.
+  5. Apply via `MongooseServer.bulkUpsert(ops)` ([database.ts](../../../classes/database.ts#L295)) — idempotent; re-running is a no-op for already-present rows.
+- `--dry` flag: prints the full upsert plan (counts per date/currency, sample rows) and writes nothing. **You review the dry-run output before the real run.**
+- Pure functions (`detectGap`, `buildUpsertOps`) separated from I/O for unit testing.
+
+## Data flow
+
+```
+BCU SOAP (date-range query)
+  → normalize rows (TCC→buy, TCV→sell, Moneda→code/type)
+  → buildUpsertOps (date @ MVD startOfDay, key origin/date/code/type)
+  → bulkUpsert into `cambio-uy`
+  → /evolution returns a continuous BCU series
+  → green line fills in
+```
+
+## Error handling
+
+- SOAP: validate `respuestastatus`, throw with `mensaje` on error; skip 0/0 rows.
+- `bcu.ts`: SOAP failure → HTML fallback (no user-visible change).
+- Backfill: per-run summary (inserted / updated / skipped); idempotent so safe to re-run;
+  `--dry` proves correctness before writing.
+- BCU only publishes business days → weekend/holiday micro-gaps remain after backfill; these
+  are small and handled by `spanGaps` (the large gap closes).
+
+## Testing (TDD)
+
+Add `vitest` to the root `devDependencies` (the repo currently has no test runner; `app/`
+already uses vitest). Unit tests cover pure functions only — no live network or DB:
+
+- `bcu_soap`: `mapRow` / `CODE_MAP` produce correct `{code,type,buy,sell}` from a fixture
+  SOAP response; `respuestastatus` error → throws; 0/0 row skipped.
+- `bcu.ts`: `get_data()` returns SOAP-mapped data; on SOAP throw, falls back to HTML (both mocked).
+- `bcu_backfill`: `detectGap` finds the right missing span from fixture docs;
+  `buildUpsertOps` yields correct filters/values and dedupes; re-applying is idempotent.
+
+Integration verification (manual, read-only): one live SOAP probe to confirm `Grupo` value,
+UR/UP codes, and response shape — no DB write.
+
+## Run plan
+
+1. Build + TDD locally with mocked SOAP/DB.
+2. Read-only live SOAP probe → confirm `Grupo`, UR/UP, response shape.
+3. Ship `bcu.ts` refactor via normal push → `main` (CI deploy).
+4. Backfill: **you** run `npm run bcu_backfill -- --dry` on the deploy server, review the
+   plan, then run `npm run bcu_backfill` for the real write against prod Mongo.
+
+## Dependencies
+
+- Add `soap` to root `package.json` dependencies.
+- Add `vitest` to root `package.json` devDependencies.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "bcu_single": "ts-node sync_bcu_single.ts",
+    "bcu_backfill": "ts-node bcu_backfill.ts",
     "prex": "ts-node prex.ts",
     "sentry_test": "ts-node sentry_test.ts",
     "bcu_details": "ts-node get_bcu_details.ts",
@@ -16,7 +17,8 @@
     "build": "tsc -p tsconfig.production.json",
     "get_locations": "ts-node get_locations.ts",
     "geo": "ts-node test_geo.ts",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "sheet_locations": "ts-node sync_locations_sheet",
     "coordinates": "ts-node update_coordinates.ts",
     "cambilex": "ts-node cambilex_sucs",
@@ -67,6 +69,7 @@
     "openai": "^6.22.0",
     "puppeteer": "^24.10.1",
     "puppeteer-core": "^24.10.1",
+    "soap": "^1.9.3",
     "socks-proxy-agent": "^8.0.5",
     "swagger-jsdoc": "^6.2.8",
     "ts-node": "^10.9.1",
@@ -75,6 +78,7 @@
   "devDependencies": {
     "@types/express": "^4.17.13",
     "@types/google-spreadsheet": "^3.3.0",
-    "nuxt-twa-module": "^1.3.1"
+    "nuxt-twa-module": "^1.3.1",
+    "vitest": "^4.1.9"
   }
 }

--- a/tests/bcu_backfill.test.ts
+++ b/tests/bcu_backfill.test.ts
@@ -1,0 +1,95 @@
+import moment from "moment-timezone";
+import { describe, expect, it } from "vitest";
+import { buildUpsertOps, chunkDateRange, detectGaps } from "../classes/bcu_backfill";
+import type { BcuQuote } from "../classes/bcu_soap";
+
+const mvd = (ymd: string) => moment.tz(ymd, "America/Montevideo").startOf("day").toDate();
+
+describe("detectGaps", () => {
+  it("finds the large missing span between two dense clusters", () => {
+    const existing = [mvd("2026-03-10"), mvd("2026-03-11"), mvd("2026-03-12"), mvd("2026-06-16"), mvd("2026-06-17")];
+    const gaps = detectGaps(existing, mvd("2026-06-17"), 4);
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0].from.getTime()).toBe(mvd("2026-03-13").getTime());
+    expect(gaps[0].to.getTime()).toBe(mvd("2026-06-15").getTime());
+  });
+
+  it("flags a trailing gap between the last data point and today", () => {
+    const existing = [mvd("2026-06-10"), mvd("2026-06-11")];
+    const gaps = detectGaps(existing, mvd("2026-06-23"), 4);
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0].from.getTime()).toBe(mvd("2026-06-12").getTime());
+    expect(gaps[0].to.getTime()).toBe(mvd("2026-06-23").getTime());
+  });
+
+  it("does not flag normal weekend-sized gaps below the threshold", () => {
+    // Fri 12th → Mon 15th is a 3-day gap; with minGapDays=4 it is not a hole.
+    const existing = [mvd("2026-06-11"), mvd("2026-06-12"), mvd("2026-06-15"), mvd("2026-06-16")];
+    const gaps = detectGaps(existing, mvd("2026-06-16"), 4);
+    expect(gaps).toEqual([]);
+  });
+
+  it("returns [] for empty input", () => {
+    expect(detectGaps([], mvd("2026-06-23"), 4)).toEqual([]);
+  });
+});
+
+describe("chunkDateRange", () => {
+  it("returns the range unchanged when it fits within maxDays", () => {
+    const chunks = chunkDateRange(mvd("2026-03-17"), mvd("2026-04-03"), 30);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].from.getTime()).toBe(mvd("2026-03-17").getTime());
+    expect(chunks[0].to.getTime()).toBe(mvd("2026-04-03").getTime());
+  });
+
+  it("splits a long range into contiguous, non-overlapping windows of at most maxDays", () => {
+    const from = mvd("2026-03-19");
+    const to = mvd("2026-06-15"); // 88 days span
+    const chunks = chunkDateRange(from, to, 30);
+
+    // Covers the full range, in order, starting and ending exactly on the bounds.
+    expect(chunks[0].from.getTime()).toBe(from.getTime());
+    expect(chunks[chunks.length - 1].to.getTime()).toBe(to.getTime());
+
+    for (const c of chunks) {
+      const span = (c.to.getTime() - c.from.getTime()) / 86_400_000;
+      expect(span).toBeLessThanOrEqual(30);
+      expect(c.to.getTime()).toBeGreaterThanOrEqual(c.from.getTime());
+    }
+    // No gap and no overlap between consecutive windows: next.from === prev.to + 1 day.
+    for (let i = 1; i < chunks.length; i++) {
+      const prevToPlus1 = chunks[i - 1].to.getTime() + 86_400_000;
+      expect(chunks[i].from.getTime()).toBe(prevToPlus1);
+    }
+  });
+});
+
+describe("buildUpsertOps", () => {
+  const quotes: BcuQuote[] = [
+    { date: mvd("2026-04-01"), code: "USD", type: "BILLETE", name: "DLS. USA BILLETE", buy: 41.9, sell: 41.9 },
+    { date: mvd("2026-04-01"), code: "UI", type: "", name: "UNIDAD INDEXADA", buy: 6.4, sell: 6.4 },
+  ];
+
+  it("builds an idempotent upsert op per quote keyed by origin/date/code/type", () => {
+    const ops = buildUpsertOps(quotes);
+    expect(ops).toEqual([
+      { filter: { origin: "bcu", date: mvd("2026-04-01"), code: "USD", type: "BILLETE" }, update: { name: "DLS. USA BILLETE", buy: 41.9, sell: 41.9 } },
+      { filter: { origin: "bcu", date: mvd("2026-04-01"), code: "UI", type: "" }, update: { name: "UNIDAD INDEXADA", buy: 6.4, sell: 6.4 } },
+    ]);
+  });
+
+  it("collapses duplicate keys, keeping the last value", () => {
+    const dup: BcuQuote[] = [
+      { date: mvd("2026-04-01"), code: "USD", type: "BILLETE", name: "DLS. USA BILLETE", buy: 1, sell: 1 },
+      { date: mvd("2026-04-01"), code: "USD", type: "BILLETE", name: "DLS. USA BILLETE", buy: 2, sell: 2 },
+    ];
+    const ops = buildUpsertOps(dup);
+    expect(ops).toHaveLength(1);
+    expect(ops[0].update).toEqual({ name: "DLS. USA BILLETE", buy: 2, sell: 2 });
+  });
+
+  it("honours a custom origin", () => {
+    const ops = buildUpsertOps([quotes[0]], "BCU");
+    expect(ops[0].filter.origin).toBe("bcu");
+  });
+});

--- a/tests/bcu_scraper.test.ts
+++ b/tests/bcu_scraper.test.ts
@@ -1,0 +1,66 @@
+import axios from "axios";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import CambioBCU from "../classes/cambios/bcu";
+import * as bcuSoap from "../classes/bcu_soap";
+
+// One HTML row in the post-2025-redesign layout the cheerio fallback expects.
+const HTML_FIXTURE = `
+  <table><tbody>
+    <tr>
+      <td class="Moneda">DLS. USA BILLETE</td>
+      <td class="Fecha">15/06/2026</td>
+      <td class="Venta">41,00</td>
+      <td class="Compra">40,00</td>
+    </tr>
+  </tbody></table>
+`;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("CambioBCU.get_data — SOAP primary", () => {
+  it("returns SOAP quotes and does not touch the HTML page when SOAP succeeds", async () => {
+    const soapSpy = vi.spyOn(bcuSoap, "fetchCurrentCotizaciones").mockResolvedValue([
+      { date: new Date(), code: "USD", type: "BILLETE", name: "DLS. USA BILLETE", buy: 40.1, sell: 40.1 },
+      { date: new Date(), code: "UI", type: "", name: "UNIDAD INDEXADA", buy: 6.5, sell: 6.5 },
+    ]);
+    const axiosSpy = vi.spyOn(axios, "get");
+
+    const cambio = new CambioBCU("bcu");
+    const data = await cambio.get_data();
+
+    expect(soapSpy).toHaveBeenCalledOnce();
+    expect(axiosSpy).not.toHaveBeenCalled();
+    expect(data).toEqual([
+      { code: "USD", type: "BILLETE", name: "DLS. USA BILLETE", buy: 40.1, sell: 40.1 },
+      { code: "UI", type: "", name: "UNIDAD INDEXADA", buy: 6.5, sell: 6.5 },
+    ]);
+  });
+});
+
+describe("CambioBCU.get_data — HTML fallback", () => {
+  it("falls back to the HTML scrape when SOAP throws", async () => {
+    vi.spyOn(bcuSoap, "fetchCurrentCotizaciones").mockRejectedValue(new Error("soap down"));
+    vi.spyOn(axios, "get").mockResolvedValue({ data: HTML_FIXTURE });
+
+    const cambio = new CambioBCU("bcu");
+    const data = await cambio.get_data();
+
+    expect(data).toEqual([
+      { code: "USD", type: "BILLETE", name: "DLS. USA BILLETE", buy: 40, sell: 41 },
+    ]);
+  });
+
+  it("falls back to the HTML scrape when SOAP returns no rows", async () => {
+    vi.spyOn(bcuSoap, "fetchCurrentCotizaciones").mockResolvedValue([]);
+    const axiosSpy = vi.spyOn(axios, "get").mockResolvedValue({ data: HTML_FIXTURE });
+
+    const cambio = new CambioBCU("bcu");
+    const data = await cambio.get_data();
+
+    expect(axiosSpy).toHaveBeenCalledOnce();
+    expect(data).toHaveLength(1);
+    expect(data[0]).toMatchObject({ code: "USD", type: "BILLETE" });
+  });
+});

--- a/tests/bcu_soap.test.ts
+++ b/tests/bcu_soap.test.ts
@@ -1,0 +1,129 @@
+import moment from "moment-timezone";
+import { describe, expect, it } from "vitest";
+import {
+  assertOk,
+  BCU_CONVERSIONS,
+  BCU_MONEDA_CODES,
+  extractRows,
+  normalizeRows,
+  parseCotizaciones,
+  toMontevideoDate,
+} from "../classes/bcu_soap";
+
+// Shape mirrors the live awsbcucotizaciones response (verified against the service).
+const okResponse = {
+  Salida: {
+    respuestastatus: { status: "1", codigoerror: 0, mensaje: "" },
+    datoscotizaciones: {
+      "datoscotizaciones.dato": [
+        { Fecha: "2026-06-15T00:00:00.000Z", Moneda: 2225, Nombre: "DLS. USA BILLETE", CodigoISO: "DLS.", TCC: 40.323, TCV: 40.5 },
+        { Fecha: "2026-06-15T00:00:00.000Z", Moneda: 9800, Nombre: "UNIDAD INDEXADA", CodigoISO: "U.I.", TCC: 6.5781, TCV: 6.5781 },
+        { Fecha: "2026-06-16T00:00:00.000Z", Moneda: 9999, Nombre: "MONEDA RARA", CodigoISO: "X", TCC: 1, TCV: 1 },
+        { Fecha: "2026-06-16T00:00:00.000Z", Moneda: 2225, Nombre: "DLS. USA BILLETE", CodigoISO: "DLS.", TCC: 0, TCV: 0 },
+      ],
+    },
+  },
+};
+
+describe("BCU_CONVERSIONS / codes", () => {
+  it("maps every requested Moneda code's name to a (code,type)", () => {
+    // Names taken from the live service; must stay in sync with the request set.
+    expect(BCU_CONVERSIONS["DLS. USA BILLETE"]).toEqual({ code: "USD", type: "BILLETE" });
+    expect(BCU_CONVERSIONS["DLS. USA CABLE"]).toEqual({ code: "USD", type: "CABLE" });
+    expect(BCU_CONVERSIONS["DLS.PROMED.FONDO"]).toEqual({ code: "USD", type: "PROMED.FONDO" });
+    expect(BCU_CONVERSIONS["PESO ARG.BILLETE"]).toEqual({ code: "ARS", type: "BILLETE" });
+    expect(BCU_CONVERSIONS["REAL BILLETE"]).toEqual({ code: "BRL", type: "BILLETE" });
+    expect(BCU_CONVERSIONS["UNIDAD INDEXADA"]).toEqual({ code: "UI", type: "" });
+    expect(BCU_CONVERSIONS["UNIDAD PREVISIONAL"]).toEqual({ code: "UP", type: "" });
+    expect(BCU_CONVERSIONS["UNIDAD REAJUSTAB"]).toEqual({ code: "UR", type: "" });
+  });
+
+  it("requests the 8 mapped Moneda codes", () => {
+    expect([...BCU_MONEDA_CODES].sort((a, b) => a - b)).toEqual([501, 1001, 2224, 2225, 2230, 9700, 9800, 9900]);
+  });
+});
+
+describe("toMontevideoDate", () => {
+  it("maps a UTC-midnight Fecha to Montevideo start-of-day without off-by-one", () => {
+    const got = toMontevideoDate("2026-06-15T00:00:00.000Z");
+    const expected = moment.tz("2026-06-15", "America/Montevideo").startOf("day").toDate();
+    expect(got.getTime()).toBe(expected.getTime());
+    // Montevideo is UTC-3 → start of the 15th is 03:00Z, NOT the 14th.
+    expect(got.toISOString()).toBe("2026-06-15T03:00:00.000Z");
+  });
+});
+
+describe("assertOk", () => {
+  it("passes when status is '1'", () => {
+    expect(() => assertOk(okResponse)).not.toThrow();
+  });
+
+  it("throws when status is not '1'", () => {
+    const bad = { Salida: { respuestastatus: { status: "0", codigoerror: 100, mensaje: "boom" } } };
+    expect(() => assertOk(bad)).toThrow(/boom/);
+  });
+});
+
+describe("extractRows", () => {
+  it("returns the dato array", () => {
+    expect(extractRows(okResponse)).toHaveLength(4);
+  });
+
+  it("wraps a single dato object into an array", () => {
+    const single = {
+      Salida: {
+        respuestastatus: { status: "1", codigoerror: 0, mensaje: "" },
+        datoscotizaciones: { "datoscotizaciones.dato": { Fecha: "2026-06-15T00:00:00.000Z", Moneda: 2225, Nombre: "DLS. USA BILLETE", TCC: 1, TCV: 1 } },
+      },
+    };
+    expect(extractRows(single)).toHaveLength(1);
+  });
+
+  it("returns [] when there are no rows", () => {
+    const empty = { Salida: { respuestastatus: { status: "1" }, datoscotizaciones: null } };
+    expect(extractRows(empty)).toEqual([]);
+  });
+});
+
+describe("normalizeRows", () => {
+  it("maps a known row by Nombre with TCC→buy, TCV→sell", () => {
+    const out = normalizeRows([okResponse.Salida.datoscotizaciones["datoscotizaciones.dato"][0]]);
+    expect(out).toEqual([
+      {
+        date: moment.tz("2026-06-15", "America/Montevideo").startOf("day").toDate(),
+        code: "USD",
+        type: "BILLETE",
+        name: "DLS. USA BILLETE",
+        buy: 40.323,
+        sell: 40.5,
+      },
+    ]);
+  });
+
+  it("skips rows whose Nombre is not in the conversions map", () => {
+    const rows = extractRows(okResponse);
+    const out = normalizeRows(rows);
+    expect(out.some((r) => r.name === "MONEDA RARA")).toBe(false);
+  });
+
+  it("skips rows where both buy and sell are 0", () => {
+    const rows = extractRows(okResponse);
+    const out = normalizeRows(rows);
+    // The 2226-06-16 USD row has TCC=TCV=0 and must be dropped.
+    expect(out.some((r) => r.code === "USD" && r.buy === 0 && r.sell === 0)).toBe(false);
+  });
+});
+
+describe("parseCotizaciones", () => {
+  it("validates status then returns only the mapped, non-zero rows", () => {
+    const out = parseCotizaciones(okResponse);
+    // 4 raw rows → drop unknown + drop 0/0 → 2 valid (USD billete 15th, UI 15th)
+    expect(out).toHaveLength(2);
+    expect(out.map((r) => `${r.code}:${r.type}`).sort()).toEqual(["UI:", "USD:BILLETE"]);
+  });
+
+  it("throws on an error response before mapping", () => {
+    const bad = { Salida: { respuestastatus: { status: "0", codigoerror: 1, mensaje: "fail" }, datoscotizaciones: null } };
+    expect(() => parseCotizaciones(bad)).toThrow(/fail/);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Why

The `/comparar` chart's BCU (green) line went flat from mid-March to mid-June 2026 — a real hole in the evolution series. Root cause: `classes/cambios/bcu.ts` scraped only BCU's HTML cotizaciones page, which broke silently on BCU's 2025 redesign, so zero BCU rows were saved for months.

## What

Make the BCU **SOAP cotizaciones** web service the primary source (stable API + historical date-range queries), keep the HTML scrape as fallback, and backfill the missing history.

- **`classes/bcu_soap.ts`** — SOAP client + pure normalization. `Nombre`→(code,type) via the same map as the HTML scraper; `TCC`→buy, `TCV`→sell; UTC `Fecha`→Montevideo start-of-day (avoids off-by-one).
- **`classes/cambios/bcu.ts`** — `get_data()` tries SOAP first, falls back to the existing cheerio scrape on error/empty. Output shape unchanged → stored docs identical.
- **`classes/bcu_backfill.ts`** — pure planning: `detectGaps`, `chunkDateRange` (SOAP rejects ranges beyond ~30 days), `buildUpsertOps`.
- **`bcu_backfill.ts`** — ts-node runner. Auto-detects gaps (or `--from/--to`), idempotent `bulkUpsert` into `cambio-uy`, `--dry` plan mode. `npm run bcu_backfill`.
- **vitest** added to root; **25 unit tests**.

## Backfill already executed (prod, 2026-06-23)

Idempotent upsert, no deletes: **+118 dates (1149→1267), 739 docs**, closed 3 gaps (2024-03, 2025-05, and the visible 2026-03-19→06-15). Re-check reports "No gaps detected." Evolution API has a 5-min Redis cache, so the chart fills after expiry.

Merging this deploys the **SOAP-primary scraper** so the daily BCU scrape stops depending on the fragile HTML page.

Spec: `docs/superpowers/specs/2026-06-23-bcu-soap-backfill-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)